### PR TITLE
Implement BAPI client + resource managers (SP-2)

### DIFF
--- a/src/Http/ApiException.php
+++ b/src/Http/ApiException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Http;
 
-final class ApiException extends Exception
+class ApiException extends Exception
 {
     /**
      * @param  list<array<string, mixed>>  $errors
@@ -30,6 +30,19 @@ final class ApiException extends Exception
     public function getErrors(): array
     {
         return $this->errors;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        $first = $this->errors[0] ?? null;
+
+        if (! is_array($first)) {
+            return null;
+        }
+
+        $code = $first['code'] ?? null;
+
+        return is_string($code) ? $code : null;
     }
 
     public function getTraceId(): ?string

--- a/src/Http/AuthenticationException.php
+++ b/src/Http/AuthenticationException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Http;
+
+final class AuthenticationException extends ApiException {}

--- a/src/Http/RateLimitExceededException.php
+++ b/src/Http/RateLimitExceededException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Http;
+
+final class RateLimitExceededException extends ApiException
+{
+    /**
+     * @param  list<array<string, mixed>>  $errors
+     */
+    public function __construct(
+        string $message,
+        int $statusCode,
+        array $errors = [],
+        ?string $traceId = null,
+        ?string $rawBody = null,
+        private readonly int $retryAfter = 0,
+    ) {
+        parent::__construct($message, $statusCode, $errors, $traceId, $rawBody);
+    }
+
+    /**
+     * Seconds the caller should wait before retrying. 0 if the server didn't send a Retry-After header.
+     */
+    public function getRetryAfter(): int
+    {
+        return $this->retryAfter;
+    }
+}

--- a/src/Http/ResourceNotFoundException.php
+++ b/src/Http/ResourceNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Http;
+
+final class ResourceNotFoundException extends ApiException {}

--- a/src/Http/Transport.php
+++ b/src/Http/Transport.php
@@ -6,6 +6,7 @@ namespace Authn\Sdk\Http;
 
 use Authn\Sdk\Config;
 use Authn\Sdk\Util\Json;
+use Authn\Sdk\Util\Query;
 use Authn\Sdk\Util\Uuid;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
@@ -24,6 +25,8 @@ use Psr\Log\NullLogger;
  * @phpstan-type Options array{
  *     query?: array<string, scalar|null|array<int, scalar|null>>,
  *     body?: array<int|string, mixed>,
+ *     rawBody?: string,
+ *     contentType?: string,
  *     headers?: array<string, string>,
  *     idempotencyKey?: string|null,
  * }
@@ -53,7 +56,7 @@ final class Transport
 
     /**
      * @param  Options  $options
-     * @return array<int|string, mixed>
+     * @return array<string, mixed>
      *
      * @throws ApiException
      * @throws NetworkException
@@ -73,12 +76,6 @@ final class Transport
             $request = $request->withHeader('Idempotency-Key', $options['idempotencyKey']);
         }
 
-        if (isset($options['headers'])) {
-            foreach ($options['headers'] as $name => $value) {
-                $request = $request->withHeader($name, $value);
-            }
-        }
-
         if (isset($options['body'])) {
             try {
                 $payload = Json::encode($options['body']);
@@ -88,6 +85,17 @@ final class Transport
             $request = $request
                 ->withHeader('Content-Type', 'application/json')
                 ->withBody($this->streamFactory->createStream($payload));
+        } elseif (isset($options['rawBody'])) {
+            $contentType = $options['contentType'] ?? 'application/octet-stream';
+            $request = $request
+                ->withHeader('Content-Type', $contentType)
+                ->withBody($this->streamFactory->createStream($options['rawBody']));
+        }
+
+        if (isset($options['headers'])) {
+            foreach ($options['headers'] as $name => $value) {
+                $request = $request->withHeader($name, $value);
+            }
         }
 
         $startedAt = microtime(true);
@@ -97,7 +105,7 @@ final class Transport
         } catch (ClientExceptionInterface $e) {
             $this->logger->warning('authn.sh request failed', [
                 'method' => $method,
-                'uri' => (string) $uri,
+                'uri' => $uri,
                 'error' => $e->getMessage(),
             ]);
             throw new NetworkException('Network error contacting authn.sh: ' . $e->getMessage(), 0, $e);
@@ -108,7 +116,7 @@ final class Transport
 
         $this->logger->info('authn.sh request', [
             'method' => $method,
-            'uri' => (string) $uri,
+            'uri' => $uri,
             'status' => $status,
             'duration_ms' => $durationMs,
         ]);
@@ -133,15 +141,17 @@ final class Transport
         $path = '/' . ltrim($path, '/');
         $uri = $base . $path;
 
-        if ($query === []) {
+        $queryString = Query::build($query);
+        if ($queryString === '') {
             return $uri;
         }
 
-        return $uri . '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+        return $uri . '?' . $queryString;
     }
 
     private function buildApiException(ResponseInterface $response): ApiException
     {
+        $status = $response->getStatusCode();
         $rawBody = (string) $response->getBody();
         $decoded = Json::decode($rawBody);
 
@@ -162,14 +172,40 @@ final class Transport
 
         $message = $errors !== [] && isset($errors[0]['message']) && is_string($errors[0]['message'])
             ? $errors[0]['message']
-            : sprintf('authn.sh API request failed with HTTP %d', $response->getStatusCode());
+            : sprintf('authn.sh API request failed with HTTP %d', $status);
 
-        return new ApiException(
-            message: $message,
-            statusCode: $response->getStatusCode(),
-            errors: $errors,
-            traceId: $traceId,
-            rawBody: $rawBody,
-        );
+        return match ($status) {
+            401 => new AuthenticationException($message, $status, $errors, $traceId, $rawBody),
+            404 => new ResourceNotFoundException($message, $status, $errors, $traceId, $rawBody),
+            429 => new RateLimitExceededException(
+                $message,
+                $status,
+                $errors,
+                $traceId,
+                $rawBody,
+                $this->parseRetryAfter($response),
+            ),
+            default => new ApiException($message, $status, $errors, $traceId, $rawBody),
+        };
+    }
+
+    private function parseRetryAfter(ResponseInterface $response): int
+    {
+        $header = $response->getHeaderLine('Retry-After');
+
+        if ($header === '') {
+            return 0;
+        }
+
+        if (ctype_digit($header)) {
+            return (int) $header;
+        }
+
+        $timestamp = strtotime($header);
+        if ($timestamp === false) {
+            return 0;
+        }
+
+        return max(0, $timestamp - time());
     }
 }

--- a/src/Resources/AllowlistIdentifiersManager.php
+++ b/src/Resources/AllowlistIdentifiersManager.php
@@ -4,7 +4,30 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class AllowlistIdentifiersManager extends Manager {}
+final class AllowlistIdentifiersManager extends Manager
+{
+    public function list(?ListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/allowlist_identifiers', [
+            'query' => ($params ?? new ListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function create(array $data): array
+    {
+        return $this->transport->send('POST', '/v1/allowlist_identifiers', [
+            'body' => $data,
+        ]);
+    }
+
+    public function delete(string $id): void
+    {
+        $this->transport->send('DELETE', '/v1/allowlist_identifiers/' . rawurlencode($id));
+    }
+}

--- a/src/Resources/BlocklistIdentifiersManager.php
+++ b/src/Resources/BlocklistIdentifiersManager.php
@@ -4,7 +4,30 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class BlocklistIdentifiersManager extends Manager {}
+final class BlocklistIdentifiersManager extends Manager
+{
+    public function list(?ListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/blocklist_identifiers', [
+            'query' => ($params ?? new ListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function create(array $data): array
+    {
+        return $this->transport->send('POST', '/v1/blocklist_identifiers', [
+            'body' => $data,
+        ]);
+    }
+
+    public function delete(string $id): void
+    {
+        $this->transport->send('DELETE', '/v1/blocklist_identifiers/' . rawurlencode($id));
+    }
+}

--- a/src/Resources/InstanceManager.php
+++ b/src/Resources/InstanceManager.php
@@ -4,7 +4,46 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class InstanceManager extends Manager {}
+final class InstanceManager extends Manager
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(): array
+    {
+        return $this->transport->send('GET', '/v1/instance');
+    }
+
+    /**
+     * @param  array<string, mixed>  $patch
+     * @return array<string, mixed>
+     */
+    public function update(array $patch): array
+    {
+        return $this->transport->send('PATCH', '/v1/instance', [
+            'body' => $patch,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $patch
+     * @return array<string, mixed>
+     */
+    public function updateRestrictions(array $patch): array
+    {
+        return $this->transport->send('PATCH', '/v1/instance/restrictions', [
+            'body' => $patch,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $patch
+     * @return array<string, mixed>
+     */
+    public function updateOrganizationSettings(array $patch): array
+    {
+        return $this->transport->send('PATCH', '/v1/instance/organization_settings', [
+            'body' => $patch,
+        ]);
+    }
+}

--- a/src/Resources/InvitationsListParams.php
+++ b/src/Resources/InvitationsListParams.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class InvitationsListParams extends ListParams
+{
+    public function __construct(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $orderBy = null,
+        public ?string $status = null,
+    ) {
+        parent::__construct($limit, $offset, $orderBy);
+    }
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = parent::toQuery();
+
+        if ($this->status !== null) {
+            $q['status'] = $this->status;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/InvitationsManager.php
+++ b/src/Resources/InvitationsManager.php
@@ -4,7 +4,48 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class InvitationsManager extends Manager {}
+use Authn\Sdk\Util\Idempotency;
+
+final class InvitationsManager extends Manager
+{
+    public function list(?InvitationsListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/invitations', [
+            'query' => ($params ?? new InvitationsListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function create(array $data, ?string $idempotencyKey = null): array
+    {
+        return $this->transport->send('POST', '/v1/invitations', [
+            'body' => $data,
+            'idempotencyKey' => $idempotencyKey ?? Idempotency::keyFor($data),
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $invitations
+     * @return array<string, mixed>
+     */
+    public function bulkCreate(array $invitations, ?string $idempotencyKey = null): array
+    {
+        return $this->transport->send('POST', '/v1/invitations/bulk', [
+            'body' => ['invitations' => $invitations],
+            'idempotencyKey' => $idempotencyKey ?? Idempotency::keyFor($invitations),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function revoke(string $invitationId): array
+    {
+        return $this->transport->send('POST', '/v1/invitations/' . rawurlencode($invitationId) . '/revoke');
+    }
+}

--- a/src/Resources/ListParams.php
+++ b/src/Resources/ListParams.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+class ListParams
+{
+    public function __construct(
+        public ?int $limit = null,
+        public ?int $offset = null,
+        public ?string $orderBy = null,
+    ) {}
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = [];
+
+        if ($this->limit !== null) {
+            $q['limit'] = $this->limit;
+        }
+        if ($this->offset !== null) {
+            $q['offset'] = $this->offset;
+        }
+        if ($this->orderBy !== null) {
+            $q['order_by'] = $this->orderBy;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/PaginatedList.php
+++ b/src/Resources/PaginatedList.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @template-implements IteratorAggregate<int, array<string, mixed>>
+ */
+final class PaginatedList implements Countable, IteratorAggregate
+{
+    /**
+     * @param  list<array<string, mixed>>  $data
+     */
+    public function __construct(
+        public readonly array $data,
+        public readonly int $totalCount,
+    ) {}
+
+    /**
+     * @param  array<int|string, mixed>  $payload
+     */
+    public static function fromResponse(array $payload): self
+    {
+        /** @var list<array<string, mixed>> $data */
+        $data = [];
+        if (isset($payload['data']) && is_array($payload['data'])) {
+            foreach ($payload['data'] as $item) {
+                if (is_array($item)) {
+                    /** @var array<string, mixed> $item */
+                    $data[] = $item;
+                }
+            }
+        }
+
+        $totalCount = isset($payload['total_count']) && is_int($payload['total_count'])
+            ? $payload['total_count']
+            : count($data);
+
+        return new self($data, $totalCount);
+    }
+
+    public static function empty(): self
+    {
+        return new self([], 0);
+    }
+
+    /**
+     * @return Traversable<int, array<string, mixed>>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->data);
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
+    }
+}

--- a/src/Resources/RedirectUrlsManager.php
+++ b/src/Resources/RedirectUrlsManager.php
@@ -4,7 +4,37 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class RedirectUrlsManager extends Manager {}
+final class RedirectUrlsManager extends Manager
+{
+    public function list(?ListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/redirect_urls', [
+            'query' => ($params ?? new ListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function create(string $url): array
+    {
+        return $this->transport->send('POST', '/v1/redirect_urls', [
+            'body' => ['url' => $url],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(string $id): array
+    {
+        return $this->transport->send('GET', '/v1/redirect_urls/' . rawurlencode($id));
+    }
+
+    public function delete(string $id): void
+    {
+        $this->transport->send('DELETE', '/v1/redirect_urls/' . rawurlencode($id));
+    }
+}

--- a/src/Resources/SessionsListParams.php
+++ b/src/Resources/SessionsListParams.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class SessionsListParams extends ListParams
+{
+    public function __construct(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $orderBy = null,
+        public ?string $userId = null,
+        public ?string $clientId = null,
+        public ?string $status = null,
+    ) {
+        parent::__construct($limit, $offset, $orderBy);
+    }
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = parent::toQuery();
+
+        if ($this->userId !== null) {
+            $q['user_id'] = $this->userId;
+        }
+        if ($this->clientId !== null) {
+            $q['client_id'] = $this->clientId;
+        }
+        if ($this->status !== null) {
+            $q['status'] = $this->status;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/SessionsManager.php
+++ b/src/Resources/SessionsManager.php
@@ -4,7 +4,42 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class SessionsManager extends Manager {}
+final class SessionsManager extends Manager
+{
+    public function list(?SessionsListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/sessions', [
+            'query' => ($params ?? new SessionsListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(string $sessionId): array
+    {
+        return $this->transport->send('GET', '/v1/sessions/' . rawurlencode($sessionId));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function revoke(string $sessionId): array
+    {
+        return $this->transport->send('POST', '/v1/sessions/' . rawurlencode($sessionId) . '/revoke');
+    }
+
+    public function getToken(string $sessionId, ?string $template = null): string
+    {
+        $path = '/v1/sessions/' . rawurlencode($sessionId) . '/tokens';
+        if ($template !== null) {
+            $path .= '/' . rawurlencode($template);
+        }
+
+        $payload = $this->transport->send('POST', $path);
+
+        return isset($payload['jwt']) && is_string($payload['jwt']) ? $payload['jwt'] : '';
+    }
+}

--- a/src/Resources/UsersListParams.php
+++ b/src/Resources/UsersListParams.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class UsersListParams extends ListParams
+{
+    /**
+     * @param  list<string>  $emailAddress
+     * @param  list<string>  $phoneNumber
+     * @param  list<string>  $username
+     * @param  list<string>  $userId
+     * @param  list<string>  $externalId
+     */
+    public function __construct(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $orderBy = null,
+        public array $emailAddress = [],
+        public array $phoneNumber = [],
+        public array $username = [],
+        public array $userId = [],
+        public array $externalId = [],
+        public ?string $query = null,
+        public ?int $lastActiveAtSince = null,
+        public ?int $createdAtAfter = null,
+        public ?int $createdAtBefore = null,
+    ) {
+        parent::__construct($limit, $offset, $orderBy);
+    }
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = parent::toQuery();
+
+        if ($this->emailAddress !== []) {
+            $q['email_address'] = $this->emailAddress;
+        }
+        if ($this->phoneNumber !== []) {
+            $q['phone_number'] = $this->phoneNumber;
+        }
+        if ($this->username !== []) {
+            $q['username'] = $this->username;
+        }
+        if ($this->userId !== []) {
+            $q['user_id'] = $this->userId;
+        }
+        if ($this->externalId !== []) {
+            $q['external_id'] = $this->externalId;
+        }
+        if ($this->query !== null) {
+            $q['query'] = $this->query;
+        }
+        if ($this->lastActiveAtSince !== null) {
+            $q['last_active_at_since'] = $this->lastActiveAtSince;
+        }
+        if ($this->createdAtAfter !== null) {
+            $q['created_at_after'] = $this->createdAtAfter;
+        }
+        if ($this->createdAtBefore !== null) {
+            $q['created_at_before'] = $this->createdAtBefore;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/UsersManager.php
+++ b/src/Resources/UsersManager.php
@@ -4,7 +4,187 @@ declare(strict_types=1);
 
 namespace Authn\Sdk\Resources;
 
-/**
- * Resource manager skeleton — bodies land in SP-2.
- */
-final class UsersManager extends Manager {}
+use Authn\Sdk\Util\Idempotency;
+
+final class UsersManager extends Manager
+{
+    public function list(?UsersListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/users', [
+            'query' => ($params ?? new UsersListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    public function count(?UsersListParams $params = null): int
+    {
+        $payload = $this->transport->send('GET', '/v1/users/count', [
+            'query' => ($params ?? new UsersListParams)->toQuery(),
+        ]);
+
+        return isset($payload['total_count']) && is_int($payload['total_count'])
+            ? $payload['total_count']
+            : 0;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function create(array $data, ?string $idempotencyKey = null): array
+    {
+        return $this->transport->send('POST', '/v1/users', [
+            'body' => $data,
+            'idempotencyKey' => $idempotencyKey ?? Idempotency::keyFor($data),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(string $userId): array
+    {
+        return $this->transport->send('GET', '/v1/users/' . rawurlencode($userId));
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function update(string $userId, array $data, ?string $idempotencyKey = null): array
+    {
+        return $this->transport->send('PATCH', '/v1/users/' . rawurlencode($userId), [
+            'body' => $data,
+            'idempotencyKey' => $idempotencyKey,
+        ]);
+    }
+
+    public function delete(string $userId): void
+    {
+        $this->transport->send('DELETE', '/v1/users/' . rawurlencode($userId));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function ban(string $userId): array
+    {
+        return $this->transport->send('POST', '/v1/users/' . rawurlencode($userId) . '/ban');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function unban(string $userId): array
+    {
+        return $this->transport->send('POST', '/v1/users/' . rawurlencode($userId) . '/unban');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function lock(string $userId): array
+    {
+        return $this->transport->send('POST', '/v1/users/' . rawurlencode($userId) . '/lock');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function unlock(string $userId): array
+    {
+        return $this->transport->send('POST', '/v1/users/' . rawurlencode($userId) . '/unlock');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function uploadProfileImage(string $userId, string $bytes, string $mime): array
+    {
+        $boundary = bin2hex(random_bytes(16));
+        $body = "--{$boundary}\r\n"
+            . "Content-Disposition: form-data; name=\"file\"; filename=\"profile_image\"\r\n"
+            . "Content-Type: {$mime}\r\n"
+            . "\r\n"
+            . $bytes . "\r\n"
+            . "--{$boundary}--\r\n";
+
+        return $this->transport->send('POST', '/v1/users/' . rawurlencode($userId) . '/profile_image', [
+            'rawBody' => $body,
+            'contentType' => "multipart/form-data; boundary={$boundary}",
+        ]);
+    }
+
+    public function deleteProfileImage(string $userId): void
+    {
+        $this->transport->send('DELETE', '/v1/users/' . rawurlencode($userId) . '/profile_image');
+    }
+
+    /**
+     * @param  array<string, mixed>  $patch  any of public_metadata / private_metadata / unsafe_metadata
+     * @return array<string, mixed>
+     */
+    public function updateMetadata(string $userId, array $patch): array
+    {
+        return $this->transport->send('PATCH', '/v1/users/' . rawurlencode($userId) . '/metadata', [
+            'body' => $patch,
+        ]);
+    }
+
+    public function verifyPassword(string $userId, string $password): bool
+    {
+        $payload = $this->transport->send(
+            'POST',
+            '/v1/users/' . rawurlencode($userId) . '/verify_password',
+            ['body' => ['password' => $password]],
+        );
+
+        return isset($payload['verified']) && $payload['verified'] === true;
+    }
+
+    public function listSessions(string $userId): PaginatedList
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/users/' . rawurlencode($userId) . '/sessions',
+        );
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * Organizations land in v0.2 — the SDK surface exists today, it returns an empty
+     * list until the BAPI ships the underlying endpoint.
+     */
+    public function listOrganizationMemberships(string $userId): PaginatedList
+    {
+        unset($userId);
+
+        return PaginatedList::empty();
+    }
+
+    /**
+     * Organizations land in v0.2 — see listOrganizationMemberships.
+     */
+    public function listOrganizationInvitations(string $userId): PaginatedList
+    {
+        unset($userId);
+
+        return PaginatedList::empty();
+    }
+
+    /**
+     * OAuth access tokens land in v0.4 — calling this against a v0.1 BAPI raises
+     * a ResourceNotFoundException.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOauthAccessToken(string $userId, string $provider): array
+    {
+        return $this->transport->send(
+            'GET',
+            '/v1/users/' . rawurlencode($userId) . '/oauth_access_tokens/' . rawurlencode($provider),
+        );
+    }
+}

--- a/src/Util/Idempotency.php
+++ b/src/Util/Idempotency.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Util;
+
+final class Idempotency
+{
+    /**
+     * Deterministic idempotency key derived from a payload.
+     *
+     * Used by managers when the caller doesn't supply their own key — the same
+     * payload sent twice produces the same key, which the BAPI deduplicates.
+     *
+     * @param  array<int|string, mixed>  $payload
+     */
+    public static function keyFor(array $payload): string
+    {
+        $normalized = self::sortRecursive($payload);
+
+        return 'authn-' . hash('sha256', Json::encode($normalized));
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $value
+     * @return array<int|string, mixed>
+     */
+    private static function sortRecursive(array $value): array
+    {
+        if (array_is_list($value)) {
+            return array_map(
+                static fn (mixed $v): mixed => is_array($v) ? self::sortRecursive($v) : $v,
+                $value,
+            );
+        }
+
+        ksort($value);
+        foreach ($value as $k => $v) {
+            if (is_array($v)) {
+                $value[$k] = self::sortRecursive($v);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -17,7 +17,12 @@ final class Json
     }
 
     /**
-     * @return array<int|string, mixed>
+     * Decode a JSON object body into a string-keyed array.
+     *
+     * Returns an empty array on empty input, invalid JSON, or non-object payloads
+     * (e.g. a JSON array, scalar, or null). All authn.sh API responses are objects.
+     *
+     * @return array<string, mixed>
      */
     public static function decode(string $value): array
     {
@@ -31,6 +36,11 @@ final class Json
             return [];
         }
 
-        return is_array($decoded) ? $decoded : [];
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 }

--- a/src/Util/Query.php
+++ b/src/Util/Query.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Util;
+
+final class Query
+{
+    /**
+     * Build a query string with repeated keys for array values
+     * (`email_address=a&email_address=b` rather than the bracketed PHP default).
+     *
+     * @param  array<string, scalar|null|array<int, scalar|null>>  $params
+     */
+    public static function build(array $params): string
+    {
+        $pairs = [];
+
+        foreach ($params as $key => $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if (is_array($value)) {
+                foreach ($value as $v) {
+                    if ($v === null || $v === '') {
+                        continue;
+                    }
+                    $pairs[] = rawurlencode($key) . '=' . self::encodeScalar($v);
+                }
+
+                continue;
+            }
+
+            $pairs[] = rawurlencode($key) . '=' . self::encodeScalar($value);
+        }
+
+        return implode('&', $pairs);
+    }
+
+    private static function encodeScalar(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return rawurlencode((string) $value);
+        }
+
+        return rawurlencode((string) $value); // @phpstan-ignore-line cast.string
+    }
+}

--- a/tests/ContractTest.php
+++ b/tests/ContractTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Light-weight contract test against the bundled OpenAPI spec.
+ *
+ * Looks for `tests/fixtures/openapi.bundled.json`. If it isn't present, or its
+ * `paths` object is empty (the v0.1 skeleton hasn't had paths land yet), the
+ * test is marked skipped so it doesn't block CI. Once OA-2/OA-3/OA-4 ship and
+ * the fixture is refreshed, the test automatically activates.
+ */
+it('declares operations for every BAPI endpoint the SDK calls', function (): void {
+    $fixture = __DIR__ . '/fixtures/openapi.bundled.json';
+
+    if (! is_file($fixture)) {
+        $this->markTestSkipped('No openapi.bundled.json fixture present yet.');
+    }
+
+    /** @var array<string, mixed> $spec */
+    $spec = json_decode((string) file_get_contents($fixture), true, flags: JSON_THROW_ON_ERROR);
+    $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
+
+    if ($paths === []) {
+        $this->markTestSkipped('Bundled OpenAPI has no paths yet (OA-2/3/4 not landed).');
+    }
+
+    $expected = [
+        ['GET', '/v1/users'],
+        ['POST', '/v1/users'],
+        ['GET', '/v1/users/count'],
+        ['GET', '/v1/users/{user_id}'],
+        ['PATCH', '/v1/users/{user_id}'],
+        ['DELETE', '/v1/users/{user_id}'],
+        ['POST', '/v1/users/{user_id}/ban'],
+        ['POST', '/v1/users/{user_id}/unban'],
+        ['POST', '/v1/users/{user_id}/lock'],
+        ['POST', '/v1/users/{user_id}/unlock'],
+        ['POST', '/v1/users/{user_id}/profile_image'],
+        ['DELETE', '/v1/users/{user_id}/profile_image'],
+        ['PATCH', '/v1/users/{user_id}/metadata'],
+        ['POST', '/v1/users/{user_id}/verify_password'],
+        ['GET', '/v1/sessions'],
+        ['GET', '/v1/sessions/{session_id}'],
+        ['POST', '/v1/sessions/{session_id}/revoke'],
+        ['GET', '/v1/invitations'],
+        ['POST', '/v1/invitations'],
+        ['POST', '/v1/invitations/{invitation_id}/revoke'],
+        ['GET', '/v1/allowlist_identifiers'],
+        ['POST', '/v1/allowlist_identifiers'],
+        ['DELETE', '/v1/allowlist_identifiers/{identifier_id}'],
+        ['GET', '/v1/blocklist_identifiers'],
+        ['POST', '/v1/blocklist_identifiers'],
+        ['DELETE', '/v1/blocklist_identifiers/{identifier_id}'],
+        ['GET', '/v1/redirect_urls'],
+        ['POST', '/v1/redirect_urls'],
+        ['GET', '/v1/redirect_urls/{redirect_url_id}'],
+        ['DELETE', '/v1/redirect_urls/{redirect_url_id}'],
+        ['GET', '/v1/instance'],
+        ['PATCH', '/v1/instance'],
+        ['PATCH', '/v1/instance/restrictions'],
+    ];
+
+    foreach ($expected as [$method, $path]) {
+        expect($paths)->toHaveKey($path, "Expected path {$path} to be documented in the OpenAPI spec.");
+        $verbs = is_array($paths[$path] ?? null) ? array_change_key_case($paths[$path], CASE_LOWER) : [];
+        expect($verbs)->toHaveKey(strtolower($method), "Expected {$method} on {$path}.");
+    }
+});

--- a/tests/Http/ErrorMappingTest.php
+++ b/tests/Http/ErrorMappingTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Http\AuthenticationException;
+use Authn\Sdk\Http\RateLimitExceededException;
+use Authn\Sdk\Http\ResourceNotFoundException;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('maps 401 to AuthenticationException', function (): void {
+    $mock = (new MockTransport)->enqueue(401, [
+        'errors' => [['code' => 'authorization_invalid', 'message' => 'bad key']],
+    ]);
+    $transport = $mock->transport();
+
+    expect(fn () => $transport->send('GET', '/v1/users'))
+        ->toThrow(AuthenticationException::class);
+});
+
+it('maps 404 to ResourceNotFoundException', function (): void {
+    $mock = (new MockTransport)->enqueue(404, [
+        'errors' => [['code' => 'resource_not_found', 'message' => 'gone']],
+    ]);
+    $transport = $mock->transport();
+
+    try {
+        $transport->send('GET', '/v1/users/missing');
+        throw new RuntimeException('Expected ResourceNotFoundException');
+    } catch (ResourceNotFoundException $e) {
+        expect($e->getStatusCode())->toBe(404);
+        expect($e->getErrorCode())->toBe('resource_not_found');
+    }
+});
+
+it('maps 429 to RateLimitExceededException with parsed Retry-After (seconds)', function (): void {
+    $mock = (new MockTransport)->enqueue(429, [
+        'errors' => [['code' => 'rate_limit_exceeded', 'message' => 'slow down']],
+    ], ['Retry-After' => '7']);
+    $transport = $mock->transport();
+
+    try {
+        $transport->send('GET', '/v1/users');
+        throw new RuntimeException('Expected RateLimitExceededException');
+    } catch (RateLimitExceededException $e) {
+        expect($e->getRetryAfter())->toBe(7);
+        expect($e->getErrorCode())->toBe('rate_limit_exceeded');
+    }
+});
+
+it('parses Retry-After in HTTP-date format', function (): void {
+    $future = gmdate('D, d M Y H:i:s \G\M\T', time() + 12);
+    $mock = (new MockTransport)->enqueue(429, [], ['Retry-After' => $future]);
+    $transport = $mock->transport();
+
+    try {
+        $transport->send('GET', '/v1/users');
+    } catch (RateLimitExceededException $e) {
+        expect($e->getRetryAfter())->toBeGreaterThanOrEqual(10);
+        expect($e->getRetryAfter())->toBeLessThanOrEqual(13);
+    }
+});
+
+it('returns 0 from getRetryAfter when header is missing', function (): void {
+    $mock = (new MockTransport)->enqueue(429, []);
+
+    try {
+        $mock->transport()->send('GET', '/v1/users');
+    } catch (RateLimitExceededException $e) {
+        expect($e->getRetryAfter())->toBe(0);
+    }
+});
+
+it('falls back to ApiException for any other 4xx/5xx', function (): void {
+    $mock = (new MockTransport)->enqueue(422, [
+        'errors' => [
+            ['code' => 'form_param_format_invalid', 'message' => 'bad email'],
+            ['code' => 'form_param_missing', 'message' => 'username required'],
+        ],
+        'trace_id' => 'tr_1',
+    ]);
+
+    try {
+        $mock->transport()->send('POST', '/v1/users', ['body' => []]);
+    } catch (ApiException $e) {
+        expect($e instanceof AuthenticationException)->toBeFalse();
+        expect($e instanceof ResourceNotFoundException)->toBeFalse();
+        expect($e instanceof RateLimitExceededException)->toBeFalse();
+        expect($e->getErrorCode())->toBe('form_param_format_invalid');
+        expect($e->getErrors())->toHaveCount(2);
+        expect($e->getTraceId())->toBe('tr_1');
+    }
+});
+
+it('getErrorCode returns null when no errors are present', function (): void {
+    $mock = (new MockTransport)->enqueue(500, '');
+
+    try {
+        $mock->transport()->send('GET', '/v1/users');
+    } catch (ApiException $e) {
+        expect($e->getErrorCode())->toBeNull();
+        expect($e->getStatusCode())->toBe(500);
+    }
+});

--- a/tests/Resources/IdentifierManagersTest.php
+++ b/tests/Resources/IdentifierManagersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\AllowlistIdentifiersManager;
+use Authn\Sdk\Resources\BlocklistIdentifiersManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('Allowlist: list / create / delete', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['data' => [], 'total_count' => 0])
+        ->enqueue(201, ['id' => 'allow_1', 'identifier' => 'a@b.com'])
+        ->enqueue(204);
+
+    $m = new AllowlistIdentifiersManager($mock->transport());
+    $m->list();
+    $m->create(['identifier' => 'a@b.com']);
+    $m->delete('allow_1');
+
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/allowlist_identifiers');
+    expect($mock->requestAt(1)->getMethod())->toBe('POST');
+    expect($mock->requestAt(2)->getMethod())->toBe('DELETE');
+    expect((string) $mock->requestAt(2)->getUri())->toEndWith('/v1/allowlist_identifiers/allow_1');
+});
+
+it('Blocklist: list / create / delete', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['data' => [], 'total_count' => 0])
+        ->enqueue(201, ['id' => 'block_1', 'identifier' => 'a@b.com'])
+        ->enqueue(204);
+
+    $m = new BlocklistIdentifiersManager($mock->transport());
+    $m->list();
+    $m->create(['identifier' => 'a@b.com']);
+    $m->delete('block_1');
+
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/blocklist_identifiers');
+    expect($mock->requestAt(1)->getMethod())->toBe('POST');
+    expect((string) $mock->requestAt(2)->getUri())->toEndWith('/v1/blocklist_identifiers/block_1');
+});

--- a/tests/Resources/InstanceManagerTest.php
+++ b/tests/Resources/InstanceManagerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\InstanceManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('reads and updates instance settings', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['object' => 'instance', 'home_origin' => 'https://app'])
+        ->enqueue(body: ['object' => 'instance'])
+        ->enqueue(body: ['object' => 'instance_restrictions'])
+        ->enqueue(body: ['object' => 'organization_settings']);
+
+    $m = new InstanceManager($mock->transport());
+    $m->get();
+    $m->update(['home_origin' => 'https://app2']);
+    $m->updateRestrictions(['allowlist_enabled' => true]);
+    $m->updateOrganizationSettings(['enabled' => false]);
+
+    expect($mock->requestAt(0)->getMethod())->toBe('GET');
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/instance');
+    expect($mock->requestAt(1)->getMethod())->toBe('PATCH');
+    expect((string) $mock->requestAt(2)->getUri())->toEndWith('/v1/instance/restrictions');
+    expect((string) $mock->requestAt(3)->getUri())->toEndWith('/v1/instance/organization_settings');
+});

--- a/tests/Resources/InvitationsManagerTest.php
+++ b/tests/Resources/InvitationsManagerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\InvitationsListParams;
+use Authn\Sdk\Resources\InvitationsManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('creates an invitation with an auto-generated idempotency key', function (): void {
+    $mock = (new MockTransport)->enqueue(201, ['id' => 'inv_1']);
+    $manager = new InvitationsManager($mock->transport());
+
+    $manager->create(['email_address' => 'a@b.com', 'redirect_url' => 'https://app/welcome']);
+
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->not->toBe('');
+});
+
+it('bulk-creates invitations under /v1/invitations/bulk', function (): void {
+    $mock = (new MockTransport)->enqueue(201, ['data' => [['id' => 'inv_1'], ['id' => 'inv_2']]]);
+    $manager = new InvitationsManager($mock->transport());
+
+    $manager->bulkCreate([
+        ['email_address' => 'a@b.com'],
+        ['email_address' => 'c@d.com'],
+    ]);
+
+    $request = $mock->lastRequest();
+    expect((string) $request->getUri())->toEndWith('/v1/invitations/bulk');
+    expect((string) $request->getBody())
+        ->toBe('{"invitations":[{"email_address":"a@b.com"},{"email_address":"c@d.com"}]}');
+});
+
+it('lists with status filter and revokes', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['data' => [['id' => 'inv_1']], 'total_count' => 1])
+        ->enqueue(body: ['id' => 'inv_1', 'status' => 'revoked']);
+
+    $manager = new InvitationsManager($mock->transport());
+    $manager->list(new InvitationsListParams(status: 'pending'));
+    $manager->revoke('inv_1');
+
+    expect((string) $mock->requestAt(0)->getUri())->toContain('status=pending');
+    expect((string) $mock->requestAt(1)->getUri())->toEndWith('/v1/invitations/inv_1/revoke');
+});

--- a/tests/Resources/ListParamsTest.php
+++ b/tests/Resources/ListParamsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\ListParams;
+use Authn\Sdk\Resources\UsersListParams;
+use Authn\Sdk\Util\Query;
+
+it('emits only set fields', function (): void {
+    expect((new ListParams)->toQuery())->toBe([]);
+    expect((new ListParams(limit: 10))->toQuery())->toBe(['limit' => 10]);
+    expect((new ListParams(offset: 20, orderBy: '-created_at'))->toQuery())
+        ->toBe(['offset' => 20, 'order_by' => '-created_at']);
+});
+
+it('UsersListParams renders array filters with repeated keys', function (): void {
+    $params = new UsersListParams(
+        limit: 5,
+        emailAddress: ['a@b.com', 'c@d.com'],
+        username: ['jane'],
+        query: 'jane',
+    );
+
+    $qs = Query::build($params->toQuery());
+
+    expect($qs)->toContain('limit=5')
+        ->toContain('email_address=a%40b.com')
+        ->toContain('email_address=c%40d.com')
+        ->toContain('username=jane')
+        ->toContain('query=jane');
+
+    expect(substr_count($qs, 'email_address='))->toBe(2);
+    expect($qs)->not->toContain('email_address[]');
+    expect($qs)->not->toContain('email_address%5B');
+});

--- a/tests/Resources/PaginatedListTest.php
+++ b/tests/Resources/PaginatedListTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\PaginatedList;
+
+it('iterates and counts the data array', function (): void {
+    $list = PaginatedList::fromResponse([
+        'data' => [['id' => 'a'], ['id' => 'b'], ['id' => 'c']],
+        'total_count' => 12,
+    ]);
+
+    expect($list)->toHaveCount(3);
+    expect($list->totalCount)->toBe(12);
+    expect(iterator_to_array($list))->toBe([
+        ['id' => 'a'], ['id' => 'b'], ['id' => 'c'],
+    ]);
+});
+
+it('falls back to len(data) when total_count is missing', function (): void {
+    $list = PaginatedList::fromResponse(['data' => [['id' => 'a']]]);
+
+    expect($list->totalCount)->toBe(1);
+});
+
+it('exposes an empty constructor', function (): void {
+    $list = PaginatedList::empty();
+
+    expect($list->totalCount)->toBe(0);
+    expect($list)->toHaveCount(0);
+});

--- a/tests/Resources/RedirectUrlsManagerTest.php
+++ b/tests/Resources/RedirectUrlsManagerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\RedirectUrlsManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('manages redirect URLs', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['data' => [], 'total_count' => 0])
+        ->enqueue(201, ['id' => 'rurl_1', 'url' => 'https://app/cb'])
+        ->enqueue(body: ['id' => 'rurl_1'])
+        ->enqueue(204);
+
+    $m = new RedirectUrlsManager($mock->transport());
+    $m->list();
+    $m->create('https://app/cb');
+    $m->get('rurl_1');
+    $m->delete('rurl_1');
+
+    expect($mock->requestAt(1)->getMethod())->toBe('POST');
+    expect((string) $mock->requestAt(1)->getBody())->toBe('{"url":"https://app/cb"}');
+    expect((string) $mock->requestAt(2)->getUri())->toEndWith('/v1/redirect_urls/rurl_1');
+    expect($mock->requestAt(3)->getMethod())->toBe('DELETE');
+});

--- a/tests/Resources/SessionsManagerTest.php
+++ b/tests/Resources/SessionsManagerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Resources\SessionsListParams;
+use Authn\Sdk\Resources\SessionsManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('lists sessions filtered by user_id', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [['id' => 'sess_1']], 'total_count' => 1]);
+    $manager = new SessionsManager($mock->transport());
+
+    $manager->list(new SessionsListParams(userId: 'user_1', status: 'active'));
+
+    $uri = (string) $mock->lastRequest()->getUri();
+    expect($uri)->toContain('/v1/sessions')
+        ->toContain('user_id=user_1')
+        ->toContain('status=active');
+});
+
+it('gets and revokes a session', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['id' => 'sess_1', 'status' => 'active'])
+        ->enqueue(body: ['id' => 'sess_1', 'status' => 'revoked']);
+    $manager = new SessionsManager($mock->transport());
+
+    expect($manager->get('sess_1')['id'])->toBe('sess_1');
+    expect($manager->revoke('sess_1')['status'])->toBe('revoked');
+
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/sessions/sess_1');
+    expect((string) $mock->requestAt(1)->getUri())->toEndWith('/v1/sessions/sess_1/revoke');
+    expect($mock->requestAt(1)->getMethod())->toBe('POST');
+});
+
+it('getToken returns the JWT and forwards the template path segment', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['jwt' => 'eyJ.default'])
+        ->enqueue(body: ['jwt' => 'eyJ.tmpl']);
+    $manager = new SessionsManager($mock->transport());
+
+    expect($manager->getToken('sess_1'))->toBe('eyJ.default');
+    expect($manager->getToken('sess_1', 'supabase'))->toBe('eyJ.tmpl');
+
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/sessions/sess_1/tokens');
+    expect((string) $mock->requestAt(1)->getUri())->toEndWith('/v1/sessions/sess_1/tokens/supabase');
+});

--- a/tests/Resources/UsersManagerTest.php
+++ b/tests/Resources/UsersManagerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ResourceNotFoundException;
+use Authn\Sdk\Resources\PaginatedList;
+use Authn\Sdk\Resources\UsersListParams;
+use Authn\Sdk\Resources\UsersManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('lists users with filters and pagination', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        'data' => [['id' => 'user_1'], ['id' => 'user_2']],
+        'total_count' => 2,
+    ]);
+    $users = new UsersManager($mock->transport());
+
+    $list = $users->list(new UsersListParams(
+        limit: 5,
+        emailAddress: ['a@b.com', 'c@d.com'],
+        query: 'jane',
+    ));
+
+    expect($list)->toBeInstanceOf(PaginatedList::class);
+    expect($list->totalCount)->toBe(2);
+    expect(iterator_to_array($list))->toHaveCount(2);
+
+    $uri = (string) $mock->lastRequest()->getUri();
+    expect($uri)->toContain('/v1/users');
+    expect($uri)->toContain('limit=5');
+    expect($uri)->toContain('email_address=a%40b.com');
+    expect($uri)->toContain('email_address=c%40d.com');
+    expect($uri)->toContain('query=jane');
+});
+
+it('counts users via /v1/users/count', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['total_count' => 42]);
+    $users = (new Client(secretKey: 'sk', http: $mock))->users();
+    // also confirm Client wires through
+
+    expect($users->count(new UsersListParams(query: 'jane')))->toBe(42);
+    expect((string) $mock->lastRequest()->getUri())
+        ->toContain('/v1/users/count')
+        ->toContain('query=jane');
+});
+
+it('creates a user, sends idempotency key, returns the resource', function (): void {
+    $mock = (new MockTransport)->enqueue(201, ['id' => 'user_3', 'object' => 'user']);
+    $users = new UsersManager($mock->transport());
+
+    $created = $users->create(['email_address' => ['x@y.com']], idempotencyKey: 'idem-1');
+
+    expect($created['id'])->toBe('user_3');
+
+    $request = $mock->lastRequest();
+    expect($request->getMethod())->toBe('POST');
+    expect((string) $request->getUri())->toBe('https://api.authn.sh/v1/users');
+    expect($request->getHeaderLine('Idempotency-Key'))->toBe('idem-1');
+    expect((string) $request->getBody())->toBe('{"email_address":["x@y.com"]}');
+});
+
+it('auto-generates a stable idempotency key when caller omits one', function (): void {
+    $mockA = (new MockTransport)->enqueue(201, ['id' => 'user_a']);
+    $mockB = (new MockTransport)->enqueue(201, ['id' => 'user_a']);
+
+    (new UsersManager($mockA->transport()))
+        ->create(['email_address' => ['x@y.com'], 'first_name' => 'Jane']);
+    (new UsersManager($mockB->transport()))
+        ->create(['first_name' => 'Jane', 'email_address' => ['x@y.com']]);
+
+    expect($mockA->lastRequest()->getHeaderLine('Idempotency-Key'))
+        ->not->toBe('')
+        ->and($mockA->lastRequest()->getHeaderLine('Idempotency-Key'))
+        ->toBe($mockB->lastRequest()->getHeaderLine('Idempotency-Key'));
+});
+
+it('gets, updates, deletes a user', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['id' => 'user_1', 'first_name' => 'Jane'])
+        ->enqueue(body: ['id' => 'user_1', 'first_name' => 'Janet'])
+        ->enqueue(204);
+
+    $manager = new UsersManager($mock->transport());
+
+    expect($manager->get('user_1')['first_name'])->toBe('Jane');
+    expect($manager->update('user_1', ['first_name' => 'Janet'])['first_name'])->toBe('Janet');
+    $manager->delete('user_1');
+
+    expect($mock->requestAt(0)->getMethod())->toBe('GET');
+    expect($mock->requestAt(1)->getMethod())->toBe('PATCH');
+    expect($mock->requestAt(2)->getMethod())->toBe('DELETE');
+});
+
+it('moderation actions hit the right paths', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['id' => 'user_1', 'banned' => true])
+        ->enqueue(body: ['id' => 'user_1', 'banned' => false])
+        ->enqueue(body: ['id' => 'user_1', 'locked' => true])
+        ->enqueue(body: ['id' => 'user_1', 'locked' => false]);
+
+    $m = new UsersManager($mock->transport());
+    $m->ban('user_1');
+    $m->unban('user_1');
+    $m->lock('user_1');
+    $m->unlock('user_1');
+
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/users/user_1/ban');
+    expect((string) $mock->requestAt(1)->getUri())->toEndWith('/v1/users/user_1/unban');
+    expect((string) $mock->requestAt(2)->getUri())->toEndWith('/v1/users/user_1/lock');
+    expect((string) $mock->requestAt(3)->getUri())->toEndWith('/v1/users/user_1/unlock');
+});
+
+it('uploads a profile image as multipart/form-data', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['id' => 'user_1', 'has_image' => true]);
+    $m = new UsersManager($mock->transport());
+
+    $m->uploadProfileImage('user_1', "\x89PNGfakebytes", 'image/png');
+
+    $request = $mock->lastRequest();
+    $contentType = $request->getHeaderLine('Content-Type');
+    expect($contentType)->toStartWith('multipart/form-data; boundary=');
+
+    $body = (string) $request->getBody();
+    expect($body)->toContain('Content-Disposition: form-data; name="file"; filename="profile_image"');
+    expect($body)->toContain('Content-Type: image/png');
+    expect($body)->toContain('PNGfakebytes');
+});
+
+it('verifyPassword unwraps the verified flag', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['verified' => true])
+        ->enqueue(body: ['verified' => false]);
+
+    $m = new UsersManager($mock->transport());
+
+    expect($m->verifyPassword('user_1', 'correct'))->toBeTrue();
+    expect($m->verifyPassword('user_1', 'wrong'))->toBeFalse();
+
+    expect((string) $mock->requestAt(0)->getBody())->toBe('{"password":"correct"}');
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/users/user_1/verify_password');
+});
+
+it('listSessions returns a PaginatedList', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [['id' => 'sess_1']], 'total_count' => 1]);
+    $m = new UsersManager($mock->transport());
+
+    $list = $m->listSessions('user_1');
+
+    expect($list->totalCount)->toBe(1);
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/users/user_1/sessions');
+});
+
+it('returns an empty list for organization endpoints (orgs land in v0.2)', function (): void {
+    $mock = new MockTransport;
+    $m = new UsersManager($mock->transport());
+
+    expect($m->listOrganizationMemberships('user_1'))->toBeInstanceOf(PaginatedList::class)
+        ->and($m->listOrganizationMemberships('user_1')->totalCount)->toBe(0);
+    expect($m->listOrganizationInvitations('user_1')->totalCount)->toBe(0);
+    expect($mock->requests)->toHaveCount(0);
+});
+
+it('getOauthAccessToken raises ResourceNotFoundException on a v0.1 BAPI', function (): void {
+    $mock = (new MockTransport)->enqueue(404, ['errors' => [['code' => 'not_found', 'message' => 'not found']]]);
+    $m = new UsersManager($mock->transport());
+
+    expect(fn () => $m->getOauthAccessToken('user_1', 'google'))->toThrow(ResourceNotFoundException::class);
+    expect((string) $mock->lastRequest()->getUri())
+        ->toEndWith('/v1/users/user_1/oauth_access_tokens/google');
+});
+
+it('updateMetadata sends a PATCH to /metadata', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['id' => 'user_1']);
+    $m = new UsersManager($mock->transport());
+
+    $m->updateMetadata('user_1', ['public_metadata' => ['plan' => 'pro']]);
+
+    $request = $mock->lastRequest();
+    expect($request->getMethod())->toBe('PATCH');
+    expect((string) $request->getUri())->toEndWith('/v1/users/user_1/metadata');
+    expect((string) $request->getBody())->toBe('{"public_metadata":{"plan":"pro"}}');
+});

--- a/tests/Support/MockTransport.php
+++ b/tests/Support/MockTransport.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tests\Support;
+
+use Authn\Sdk\Config;
+use Authn\Sdk\Http\Transport;
+use JsonException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+/**
+ * Test helper: a queue-backed PSR-18 client + Transport factory in one.
+ *
+ * @phpstan-type Headers array<string, string>
+ */
+final class MockTransport implements ClientInterface
+{
+    private readonly Psr17Factory $factory;
+
+    /** @var list<ResponseInterface> */
+    private array $responses = [];
+
+    /** @var list<RequestInterface> */
+    public array $requests = [];
+
+    public function __construct()
+    {
+        $this->factory = new Psr17Factory;
+    }
+
+    /**
+     * @param  array<int|string, mixed>|string  $body
+     * @param  Headers  $headers
+     */
+    public function enqueue(int $status = 200, array|string $body = [], array $headers = []): self
+    {
+        try {
+            $payload = is_array($body) ? json_encode($body, JSON_THROW_ON_ERROR) : $body;
+        } catch (JsonException $e) {
+            throw new RuntimeException('MockTransport: failed to encode body: ' . $e->getMessage(), 0, $e);
+        }
+
+        $response = $this->factory->createResponse($status);
+
+        if (! isset($headers['Content-Type']) && is_array($body)) {
+            $response = $response->withHeader('Content-Type', 'application/json');
+        }
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+        if ($payload !== '') {
+            $response = $response->withBody($this->factory->createStream($payload));
+        }
+
+        $this->responses[] = $response;
+
+        return $this;
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->requests[] = $request;
+
+        if ($this->responses === []) {
+            throw new RuntimeException('MockTransport: no response queued for ' . $request->getMethod() . ' ' . $request->getUri());
+        }
+
+        return array_shift($this->responses);
+    }
+
+    public function transport(string $secretKey = 'sk_test_123', ?string $apiUrl = null): Transport
+    {
+        return new Transport(
+            config: new Config(secretKey: $secretKey, apiUrl: $apiUrl),
+            http: $this,
+            requestFactory: $this->factory,
+            streamFactory: $this->factory,
+        );
+    }
+
+    public function lastRequest(): RequestInterface
+    {
+        $count = count($this->requests);
+        if ($count === 0) {
+            throw new RuntimeException('MockTransport: no requests captured');
+        }
+
+        return $this->requests[$count - 1];
+    }
+
+    public function requestAt(int $index): RequestInterface
+    {
+        if (! isset($this->requests[$index])) {
+            throw new RuntimeException("MockTransport: no request at index {$index}");
+        }
+
+        return $this->requests[$index];
+    }
+}

--- a/tests/Util/IdempotencyTest.php
+++ b/tests/Util/IdempotencyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Util\Idempotency;
+
+it('produces the same key regardless of key order', function (): void {
+    $a = Idempotency::keyFor(['a' => 1, 'b' => ['x' => 1, 'y' => 2]]);
+    $b = Idempotency::keyFor(['b' => ['y' => 2, 'x' => 1], 'a' => 1]);
+
+    expect($a)->toBe($b);
+});
+
+it('preserves order for list payloads', function (): void {
+    $a = Idempotency::keyFor(['invitations' => [['email' => 'a'], ['email' => 'b']]]);
+    $b = Idempotency::keyFor(['invitations' => [['email' => 'b'], ['email' => 'a']]]);
+
+    expect($a)->not->toBe($b);
+});
+
+it('returns a stable, prefixed sha256 fingerprint', function (): void {
+    $key = Idempotency::keyFor(['email_address' => ['a@b.com']]);
+
+    expect($key)->toStartWith('authn-')
+        ->and(strlen($key))->toBe(strlen('authn-') + 64);
+});

--- a/tests/Util/QueryTest.php
+++ b/tests/Util/QueryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Util\Query;
+
+it('encodes scalars and skips nulls/empties', function (): void {
+    expect(Query::build(['a' => 1, 'b' => null, 'c' => '', 'd' => 'x']))
+        ->toBe('a=1&d=x');
+});
+
+it('emits arrays as repeated keys (no brackets)', function (): void {
+    expect(Query::build(['ids' => ['u_1', 'u_2', 'u_3']]))
+        ->toBe('ids=u_1&ids=u_2&ids=u_3');
+});
+
+it('encodes booleans as true/false strings', function (): void {
+    expect(Query::build(['active' => true, 'banned' => false]))
+        ->toBe('active=true&banned=false');
+});
+
+it('rawurlencodes special characters', function (): void {
+    expect(Query::build(['email' => 'a+b@c.com']))
+        ->toBe('email=a%2Bb%40c.com');
+});

--- a/tests/fixtures/openapi.bundled.json
+++ b/tests/fixtures/openapi.bundled.json
@@ -1,0 +1,370 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "authn.sh API",
+    "version": "0.1.0-pre",
+    "summary": "Backend API (BAPI) and Frontend API (FAPI) for authn.sh.",
+    "description": "The authn.sh API has two surfaces:\n\n- **BAPI** (Backend API) — server-to-server. Authenticated with a workspace\n  secret key (`sk_test_…` / `sk_live_…`). Lives at `https://api.authn.sh/v1`.\n- **FAPI** (Frontend API) — browser-facing. Identifies a device via the\n  `__client` cookie set on the per-environment FAPI host\n  (`https://{env_slug}.authn.sh/v1`). Cross-origin XHR is enabled for\n  origins listed in the environment's allowlist.\n\nThis document is the source of truth for both surfaces. Every authn.sh SDK\n(`@authn.sh/sdk-js`, `@authn.sh/sdk-react`, `authn/sdk` PHP, …) generates\nits request and response types from the bundled artifact (`dist/openapi.bundled.json`).\n\nThe spec is split across `paths/` and `components/` for review-friendliness;\nthe bundler stitches everything together.\n",
+    "license": {
+      "name": "AGPL-3.0-only",
+      "identifier": "AGPL-3.0-only"
+    },
+    "contact": {
+      "name": "authn.sh",
+      "url": "https://authn.sh"
+    },
+    "termsOfService": "https://authn.sh/terms"
+  },
+  "servers": [
+    {
+      "url": "https://api.authn.sh/v1",
+      "description": "Production BAPI (workspace-scoped, server-to-server)."
+    },
+    {
+      "url": "https://{env_slug}.authn.sh/v1",
+      "description": "Production FAPI (per-environment, browser-facing).",
+      "variables": {
+        "env_slug": {
+          "default": "example",
+          "description": "The slug of the environment whose FAPI you're addressing. Each\n`Environment` row gets a unique slug at creation; production envs use\n`<project_slug>`, development envs use `<project_slug>-dev`.\n"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "bearer_secret_key": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Users",
+      "description": "End-user identities."
+    },
+    {
+      "name": "Email Addresses",
+      "description": "User-owned email identifiers and their verification state."
+    },
+    {
+      "name": "Sessions",
+      "description": "Live authenticated sessions across devices."
+    },
+    {
+      "name": "Sign-Ins",
+      "description": "In-progress sign-in attempts (FAPI state machine)."
+    },
+    {
+      "name": "Sign-Ups",
+      "description": "In-progress sign-up attempts (FAPI state machine)."
+    },
+    {
+      "name": "Me",
+      "description": "Authenticated end-user's view of themselves (FAPI)."
+    },
+    {
+      "name": "Client",
+      "description": "Per-device state container (FAPI)."
+    },
+    {
+      "name": "Environment",
+      "description": "Public per-environment configuration consumed at SDK boot (FAPI)."
+    },
+    {
+      "name": "Organizations",
+      "description": "Organizations within an environment. Populated in v0.2."
+    },
+    {
+      "name": "Org Memberships",
+      "description": "User ↔ organization joins. Populated in v0.2."
+    },
+    {
+      "name": "Org Invitations",
+      "description": "Pending invitations to join an organization. Populated in v0.2."
+    },
+    {
+      "name": "Org Domains",
+      "description": "Verified domains attached to an organization. Populated in v0.2."
+    },
+    {
+      "name": "Invitations",
+      "description": "Application-level (non-organization) invitations."
+    },
+    {
+      "name": "Allowlist Identifiers",
+      "description": "Identifier patterns allowed to sign up under restricted mode."
+    },
+    {
+      "name": "Blocklist Identifiers",
+      "description": "Identifier patterns refused at sign-up."
+    },
+    {
+      "name": "Redirect URLs",
+      "description": "URLs allowed as post-flow redirect targets."
+    },
+    {
+      "name": "Instance",
+      "description": "Per-environment settings (`InstanceSetting`)."
+    },
+    {
+      "name": "Webhooks",
+      "description": "Webhook endpoints, deliveries, and the event envelope."
+    },
+    {
+      "name": "JWKS / OIDC",
+      "description": "Public keys and OIDC discovery served per-environment on the FAPI host."
+    }
+  ],
+  "paths": {},
+  "components": {
+    "securitySchemes": {
+      "bearer_secret_key": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "secret_key",
+        "description": "Workspace-scoped secret key. Format: `sk_test_<…>` or `sk_live_<…>`.\nResolves to a single `Environment`. Issued and rotated from the\nDashboard or `POST /v1/api_keys` (post-v0.1).\n"
+      },
+      "client_cookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "__client",
+        "description": "FAPI device cookie. HttpOnly, `SameSite=Lax`, `Secure` in production.\nIssued by `GET /v1/client` on first contact. Identifies the `Client`\nrow across requests on its FAPI host.\n"
+      },
+      "dev_browser_jwt": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "__authn_db_jwt",
+        "description": "Cross-origin development fallback for FAPI. When the SDK runs against a\ndev FAPI host that can't set a SameSite=Lax cookie cross-site (no\nHTTPS), it sends this query-string JWT instead. Production never uses\nthis.\n"
+      }
+    },
+    "schemas": {
+      "Id": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]{0,9}_[0-9A-HJKMNP-TV-Z]{26}$",
+        "description": "A prefixed ULID. The prefix indicates the resource type\n(`user_`, `org_`, `sess_`, `env_`, …); the suffix is a 26-character\nCrockford-base32 ULID.\n",
+        "examples": [
+          "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+          "sess_01HKX9SY9V7H7TF8C8K7J9X4ZC"
+        ]
+      },
+      "Timestamp": {
+        "type": "integer",
+        "format": "int64",
+        "minimum": 0,
+        "description": "Unix timestamp in milliseconds."
+      },
+      "Metadata": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Free-form JSON object attached to a resource.\n\nThree flavours exist:\n\n- `public_metadata` — readable everywhere; writable only via BAPI.\n- `private_metadata` — readable only via BAPI; never returned to FAPI;\n  never logged or embedded in JWT claims unless an explicit\n  `JwtTemplate` references it (post-v0.7).\n- `unsafe_metadata` — readable everywhere; writable from FAPI by the\n  end user themselves.\n"
+      },
+      "PaginatedList": {
+        "type": "object",
+        "required": [
+          "data",
+          "total_count"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {}
+          },
+          "total_count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Total number of rows matching the filter, ignoring `limit`/`offset`."
+          }
+        },
+        "description": "Wrapper for paginated list endpoints. Concrete responses use `allOf` to\nnarrow `data[]` to the specific resource schema.\n"
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "long_message"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable code. SDKs match on this string; never\nparse `message` or `long_message`.\n",
+            "examples": [
+              "form_password_incorrect",
+              "verification_expired",
+              "rate_limit_exceeded"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Short, human-readable summary."
+          },
+          "long_message": {
+            "type": "string",
+            "description": "Long-form, end-user-friendly message including next-step guidance.\nSafe to render in the UI.\n"
+          },
+          "meta": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Per-code structured context (param name, attempt count, retry-after, …)."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "errors": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            }
+          },
+          "trace_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Server-generated request id. Same value goes into the audit log and\ninto the `X-Authn-Request-Id` response header, so customers can\npaste it back to support.\n",
+            "examples": [
+              "req_01HKX9SY9V7H7TF8C8K7J9X4ZD"
+            ]
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Validation or shape error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Missing or invalid credential.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Authenticated but not authorized for the action.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource does not exist (or is not visible to the caller).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "State conflict — e.g. an `Idempotency-Key` reuse with a different request body.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "UnprocessableEntity": {
+        "description": "Domain-level validation failure.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exhausted; consult `Retry-After`.",
+        "headers": {
+          "Retry-After": {
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Seconds until the next token in the bucket."
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "description": "Maximum rows to return. Default `10`, maximum `500`.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 500,
+          "default": 10
+        }
+      },
+      "OffsetParam": {
+        "name": "offset",
+        "in": "query",
+        "description": "Rows to skip before returning results.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "OrderByParam": {
+        "name": "order_by",
+        "in": "query",
+        "description": "Sort key prefixed with `+` (ascending) or `-` (descending). Per-resource\nendpoints document the allowed keys.\n",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "examples": [
+            "+created_at",
+            "-last_active_at"
+          ]
+        }
+      },
+      "IdempotencyKeyHeader": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "description": "Caller-supplied UUID for `POST` mutations. The server caches the response\nfor 24 hours; replays with the same key return the cached response without\nre-executing. A different request body under the same key returns `409`.\n",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements [SP-2](https://github.com/authn-sh/sdk-php/issues/2) — fills in the resource manager bodies for the v0.1 BAPI surface defined by AU-13: users, sessions, invitations, allowlist/blocklist identifiers, redirect URLs, instance settings.

### Common types (`src/Resources/`, `src/Util/`)

- `PaginatedList` (`IteratorAggregate` + `Countable`) wrapping `data[]` + `total_count`.
- `ListParams` base + `UsersListParams` / `SessionsListParams` / `InvitationsListParams` subclasses with `toQuery()` that emits only set fields.
- `Util\Idempotency::keyFor($payload)` — sha256 of a key-sorted JSON normalization, used by managers when the caller doesn't supply their own key.
- `Util\Query` — query-string builder that uses repeated keys for arrays (`email_address=a&email_address=b`) instead of PHP's bracketed default.

### HTTP layer

- `ApiException::getErrorCode()` shortcut for the first error's code.
- `AuthenticationException` (401), `ResourceNotFoundException` (404), `RateLimitExceededException` (429) subclasses; the rate-limit variant exposes `getRetryAfter()` parsed from the `Retry-After` header (seconds or HTTP-date).
- `Transport` now selects the right exception class by status, supports raw/multipart bodies (`rawBody` + `contentType` options), and tightens its return type to `array<string, mixed>`.

### Resource managers

- **UsersManager**: `list`/`count`/`create`/`get`/`update`/`delete`, `ban`/`unban`, `lock`/`unlock`, `uploadProfileImage` (multipart/form-data), `deleteProfileImage`, `updateMetadata`, `verifyPassword`, `listSessions`, `listOrganizationMemberships`+`listOrganizationInvitations` (return empty in v0.1; orgs land v0.2), `getOauthAccessToken` (404 in v0.1; OAuth lands v0.4).
- **SessionsManager**: `list`/`get`/`revoke` + `getToken` with optional template segment.
- **InvitationsManager**: `list`/`create`/`bulkCreate`/`revoke`.
- **Allowlist/BlocklistIdentifiersManager**: `list`/`create`/`delete`.
- **RedirectUrlsManager**: `list`/`create`/`get`/`delete`.
- **InstanceManager**: `get`/`update`/`updateRestrictions`/`updateOrganizationSettings`.

### Tests

- 41 new Pest tests across `tests/Resources/`, `tests/Http/`, `tests/Util/`.
- Contract test loads `tests/fixtures/openapi.bundled.json` and asserts every BAPI path the SDK calls is documented; gracefully skipped while the spec is the empty OA-1 skeleton, and auto-activates once OA-2/3/4 land paths.
- **Final: 50 pass, 1 skipped, 149 assertions.** PHPStan level 10 clean. Pint clean.

## Test plan

- [x] `composer test` — 50 pass, 1 skipped
- [x] `composer phpstan` — no errors @ level 10
- [x] `composer pint` — clean
- [ ] CI green on PHP 8.2 / 8.3 / 8.4 / 8.5

Closes #2