### PR TITLE
Implement JWT verifier + webhook signature verifier (SP-3, no Laravel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # authn-sh/sdk-php
 
-PHP backend SDK for [authn.sh](https://authn.sh) — call the Backend API (BAPI), verify session JWTs, and verify webhook signatures from server-side PHP. Ships with a thin Laravel package layer.
+PHP backend SDK for [authn.sh](https://authn.sh) — call the Backend API (BAPI), verify session JWTs, and verify webhook signatures from server-side PHP. The Laravel integration lives in the separate [`authn-sh/sdk-php-laravel`](https://github.com/authn-sh/sdk-php-laravel) package.
 
 > Status: **0.1.x pre-release.** APIs may change before `1.0`.
 
@@ -8,6 +8,7 @@ PHP backend SDK for [authn.sh](https://authn.sh) — call the Backend API (BAPI)
 
 - PHP **8.2+**
 - A PSR-18 HTTP client (Guzzle, Symfony HttpClient, etc.) and PSR-17 factories. The SDK auto-discovers them via [`php-http/discovery`](https://docs.php-http.org/en/latest/discovery.html), so installing `guzzlehttp/guzzle` (or any PSR-18 client) is enough.
+- A PSR-16 cache (optional, for the JWT verifier). Without one the JWKS document is re-fetched on every verify.
 
 ## Install
 
@@ -21,7 +22,7 @@ If you don't already have a PSR-18 client in your project:
 composer require guzzlehttp/guzzle
 ```
 
-## Usage
+## BAPI client
 
 ```php
 use Authn\Sdk\Client;
@@ -29,9 +30,11 @@ use Authn\Sdk\Client;
 $client = new Client(secretKey: $_ENV['AUTHN_SECRET_KEY']);
 
 $user = $client->users()->get('user_2x4yT…');
+$session = $client->sessions()->revoke('sess_…');
+$invite = $client->invitations()->create(['email_address' => 'a@b.com']);
 ```
 
-Resource managers (`users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`) are wired up in this release; their full method bodies land in the next milestone.
+Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`.
 
 ### Custom HTTP client / logger
 
@@ -49,10 +52,58 @@ $client = new Client(
 
 ### Errors
 
-The transport throws:
+- `Authn\Sdk\Http\ApiException` — non-2xx responses; `getStatusCode()`, `getErrors()`, `getErrorCode()`, `getTraceId()`, `getRawBody()`.
+- `Authn\Sdk\Http\AuthenticationException` (401), `Authn\Sdk\Http\ResourceNotFoundException` (404), `Authn\Sdk\Http\RateLimitExceededException` (429, with `getRetryAfter()`).
+- `Authn\Sdk\Http\NetworkException` — connection-level failures.
 
-- `Authn\Sdk\Http\ApiException` for non-2xx responses, with `getStatusCode()`, `getErrors()` (the parsed `errors[]` envelope), `getTraceId()`, and `getRawBody()`.
-- `Authn\Sdk\Http\NetworkException` for connection-level failures.
+## Verify a session JWT
+
+```php
+use Authn\Sdk\Tokens\TokenVerifier;
+use Authn\Sdk\Tokens\TokenInvalidException;
+
+$verifier = new TokenVerifier(
+    publishableKey: $_ENV['AUTHN_PUBLISHABLE_KEY'], // pk_test_… / pk_live_…
+    cache: $psr16Cache,                              // optional PSR-16 cache for JWKS
+);
+
+try {
+    $claims = $verifier->verify($jwt);                 // throws TokenInvalidException
+    // or: $claims = $verifier->tryVerify($jwt);       // returns null on failure
+
+    $userId = $claims->sub;       // user_…
+    $sessionId = $claims->sid;    // sess_…
+} catch (TokenInvalidException $e) {
+    // 401 the request
+}
+
+// Optional: enforce origin binding via the azp claim.
+$claims = $verifier->verify($jwt, expectedAzp: ['https://app.acme.com']);
+```
+
+The verifier fetches the FAPI JWKS once and caches it (PSR-16). On an unknown `kid` it refreshes the JWKS once before failing.
+
+## Verify a webhook
+
+```php
+use Authn\Sdk\Webhooks\SignatureVerifier;
+use Authn\Sdk\Webhooks\SignatureInvalidException;
+
+// One signing secret, or many during a rotation overlap window.
+$verifier = new SignatureVerifier($_ENV['AUTHN_WEBHOOK_SECRET']);
+
+try {
+    $event = $verifier->verify($rawBody, $request->getHeaders()); // throws SignatureInvalidException
+
+    if ($event->type === 'user.created') {
+        // $event->data carries the resource payload
+    }
+} catch (SignatureInvalidException $e) {
+    // 401 the request
+}
+```
+
+Replay protection is on by default with a 5-minute tolerance — pass `toleranceSeconds:` to widen or narrow it.
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "authn-sh/sdk-php",
-    "description": "PHP backend SDK for authn.sh — BAPI client, JWT verification, webhook signature verification, Laravel package.",
+    "description": "PHP backend SDK for authn.sh — BAPI client, JWT verification, and webhook signature verification.",
     "keywords": [
         "authn",
         "authentication",
@@ -17,12 +17,13 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
+        "php-http/discovery": "^1.19",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^3.0",
-        "web-token/jwt-library": "^4.0",
-        "php-http/discovery": "^1.19"
+        "psr/simple-cache": "^3.0",
+        "web-token/jwt-library": "^4.0"
     },
     "require-dev": {
         "pestphp/pest": "^3.0",
@@ -56,11 +57,6 @@
         }
     },
     "extra": {
-        "laravel": {
-            "providers": [
-                "Authn\\Sdk\\Laravel\\AuthnServiceProvider"
-            ]
-        },
         "branch-alias": {
             "dev-main": "0.1.x-dev"
         }

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Cache;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Default cache used by TokenVerifier when the caller doesn't pass a PSR-16 cache.
+ *
+ * Every read is a miss and every write is a no-op, so the JWKS document will be
+ * re-fetched on every verify(). For production workloads, inject a real PSR-16 cache.
+ */
+final class NullCache implements CacheInterface
+{
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $default;
+    }
+
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    {
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $out = [];
+        foreach ($keys as $key) {
+            $out[$key] = $default;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  iterable<string, mixed>  $values
+     */
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        return false;
+    }
+}

--- a/src/Tokens/TokenInvalidException.php
+++ b/src/Tokens/TokenInvalidException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tokens;
+
+use RuntimeException;
+
+final class TokenInvalidException extends RuntimeException {}

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -185,7 +185,20 @@ final class TokenVerifier
     private function findKey(JWKSet $jwks, ?string $kid): ?JWK
     {
         if ($kid === null) {
-            return $jwks->count() === 1 ? $jwks->selectKey('sig') ?? $jwks->all()[array_key_first($jwks->all())] : null;
+            if ($jwks->count() !== 1) {
+                return null;
+            }
+
+            $key = $jwks->selectKey('sig');
+            if ($key !== null) {
+                return $key;
+            }
+
+            foreach ($jwks->all() as $jwk) {
+                return $jwk;
+            }
+
+            return null;
         }
 
         try {

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tokens;
+
+use Authn\Sdk\Cache\NullCache;
+use Authn\Sdk\Util\Json;
+use Authn\Sdk\Util\PublishableKey;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\Algorithm\ES384;
+use Jose\Component\Signature\Algorithm\ES512;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\SimpleCache\CacheInterface;
+use Throwable;
+
+/**
+ * Verifies session JWTs issued by an authn.sh Frontend API.
+ *
+ * Fetches the FAPI's JWKS once and caches it in PSR-16 for `jwksCacheTtlSeconds`.
+ * On an unknown `kid` the cache is bypassed and the JWKS re-fetched once;
+ * still missing → `TokenInvalidException`.
+ */
+final class TokenVerifier
+{
+    public const SUPPORTED_ALGORITHMS = ['RS256', 'ES256', 'ES384', 'ES512'];
+
+    private readonly string $frontendApiUrl;
+
+    private readonly ClientInterface $http;
+
+    private readonly RequestFactoryInterface $requestFactory;
+
+    private readonly CacheInterface $cache;
+
+    private readonly JWSVerifier $verifier;
+
+    private readonly CompactSerializer $serializer;
+
+    public function __construct(
+        string $publishableKey,
+        ?string $frontendApiUrl = null,
+        ?CacheInterface $cache = null,
+        ?ClientInterface $http = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        private readonly int $jwksCacheTtlSeconds = 600,
+        private readonly int $allowedClockSkewSeconds = 5,
+    ) {
+        $this->frontendApiUrl = $frontendApiUrl !== null && $frontendApiUrl !== ''
+            ? rtrim($frontendApiUrl, '/')
+            : PublishableKey::frontendApiUrl($publishableKey);
+
+        $this->cache = $cache ?? new NullCache;
+        $this->http = $http ?? Psr18ClientDiscovery::find();
+        $this->requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
+
+        $this->verifier = new JWSVerifier(new AlgorithmManager([
+            new RS256,
+            new ES256,
+            new ES384,
+            new ES512,
+        ]));
+        $this->serializer = new CompactSerializer;
+    }
+
+    /**
+     * @param  list<string>  $expectedAzp  if non-empty, the token's `azp` claim must match one of these
+     *
+     * @throws TokenInvalidException
+     */
+    public function verify(string $jwt, array $expectedAzp = []): VerifiedClaims
+    {
+        try {
+            $jws = $this->serializer->unserialize($jwt);
+        } catch (Throwable $e) {
+            throw new TokenInvalidException('Malformed JWT: ' . $e->getMessage(), 0, $e);
+        }
+
+        $signature = $jws->getSignature(0);
+        $header = $signature->getProtectedHeader();
+        $kid = isset($header['kid']) && is_string($header['kid']) ? $header['kid'] : null;
+        $alg = isset($header['alg']) && is_string($header['alg']) ? $header['alg'] : null;
+
+        if ($alg === null || ! in_array($alg, self::SUPPORTED_ALGORITHMS, true)) {
+            throw new TokenInvalidException('Unsupported JWT algorithm: ' . ($alg ?? '<missing>'));
+        }
+
+        $jwk = $this->resolveKey($kid);
+
+        if (! $this->verifier->verifyWithKey($jws, $jwk, 0)) {
+            throw new TokenInvalidException('Invalid JWT signature.');
+        }
+
+        $payload = $jws->getPayload();
+        $claims = $payload === null ? [] : Json::decode($payload);
+        if ($claims === []) {
+            throw new TokenInvalidException('JWT payload is not a JSON object.');
+        }
+
+        return $this->buildVerifiedClaims($claims, $expectedAzp);
+    }
+
+    /**
+     * @param  list<string>  $expectedAzp
+     */
+    public function tryVerify(string $jwt, array $expectedAzp = []): ?VerifiedClaims
+    {
+        try {
+            return $this->verify($jwt, $expectedAzp);
+        } catch (TokenInvalidException) {
+            return null;
+        }
+    }
+
+    private function resolveKey(?string $kid): JWK
+    {
+        $jwks = $this->getJwksFromCache();
+        $key = $jwks !== null ? $this->findKey($jwks, $kid) : null;
+
+        if ($key === null) {
+            $jwks = $this->refreshJwks();
+            $key = $this->findKey($jwks, $kid);
+        }
+
+        if ($key === null) {
+            throw new TokenInvalidException('No matching JWK for kid ' . ($kid ?? '<none>'));
+        }
+
+        return $key;
+    }
+
+    private function getJwksFromCache(): ?JWKSet
+    {
+        $cached = $this->cache->get($this->cacheKey());
+        if (! is_string($cached) || $cached === '') {
+            return null;
+        }
+
+        try {
+            return JWKSet::createFromJson($cached);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function refreshJwks(): JWKSet
+    {
+        $url = $this->frontendApiUrl . '/.well-known/jwks.json';
+        $request = $this->requestFactory->createRequest('GET', $url)
+            ->withHeader('Accept', 'application/json');
+
+        try {
+            $response = $this->http->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            throw new TokenInvalidException('Failed to fetch JWKS: ' . $e->getMessage(), 0, $e);
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            throw new TokenInvalidException('Failed to fetch JWKS: HTTP ' . $response->getStatusCode());
+        }
+
+        $body = (string) $response->getBody();
+
+        try {
+            $jwks = JWKSet::createFromJson($body);
+        } catch (Throwable $e) {
+            throw new TokenInvalidException('Malformed JWKS document: ' . $e->getMessage(), 0, $e);
+        }
+
+        $this->cache->set($this->cacheKey(), $body, $this->jwksCacheTtlSeconds);
+
+        return $jwks;
+    }
+
+    private function findKey(JWKSet $jwks, ?string $kid): ?JWK
+    {
+        if ($kid === null) {
+            return $jwks->count() === 1 ? $jwks->selectKey('sig') ?? $jwks->all()[array_key_first($jwks->all())] : null;
+        }
+
+        try {
+            return $jwks->get($kid);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     * @param  list<string>  $expectedAzp
+     */
+    private function buildVerifiedClaims(array $claims, array $expectedAzp): VerifiedClaims
+    {
+        $now = time();
+        $skew = $this->allowedClockSkewSeconds;
+
+        $iss = isset($claims['iss']) && is_string($claims['iss']) ? $claims['iss'] : null;
+        if ($iss === null || rtrim($iss, '/') !== rtrim($this->frontendApiUrl, '/')) {
+            throw new TokenInvalidException('JWT issuer does not match the configured Frontend API URL.');
+        }
+
+        $exp = isset($claims['exp']) && is_int($claims['exp']) ? $claims['exp'] : null;
+        if ($exp === null) {
+            throw new TokenInvalidException('JWT is missing the exp claim.');
+        }
+        if ($exp + $skew < $now) {
+            throw new TokenInvalidException('JWT has expired.');
+        }
+
+        $iat = isset($claims['iat']) && is_int($claims['iat']) ? $claims['iat'] : null;
+        if ($iat === null) {
+            throw new TokenInvalidException('JWT is missing the iat claim.');
+        }
+        if ($iat - $skew > $now) {
+            throw new TokenInvalidException('JWT iat is in the future.');
+        }
+
+        $nbf = isset($claims['nbf']) && is_int($claims['nbf']) ? $claims['nbf'] : null;
+        if ($nbf !== null && $nbf - $skew > $now) {
+            throw new TokenInvalidException('JWT is not yet valid (nbf in the future).');
+        }
+
+        $sub = isset($claims['sub']) && is_string($claims['sub']) ? $claims['sub'] : '';
+        $sid = isset($claims['sid']) && is_string($claims['sid']) ? $claims['sid'] : '';
+        if ($sub === '' || $sid === '') {
+            throw new TokenInvalidException('JWT is missing the sub or sid claim.');
+        }
+
+        $azp = isset($claims['azp']) && is_string($claims['azp']) ? $claims['azp'] : null;
+        if ($expectedAzp !== [] && ! in_array($azp, $expectedAzp, true)) {
+            throw new TokenInvalidException('JWT azp does not match any expected value.');
+        }
+
+        /** @var array{iss: string, sub: string, sid: string}|null $actor */
+        $actor = isset($claims['act']) && is_array($claims['act']) ? $this->normalizeActor($claims['act']) : null;
+        /** @var array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null $org */
+        $org = isset($claims['org']) && is_array($claims['org']) ? $this->normalizeOrg($claims['org']) : null;
+
+        return new VerifiedClaims(
+            sub: $sub,
+            sid: $sid,
+            iss: $iss,
+            azp: $azp,
+            exp: $exp,
+            iat: $iat,
+            nbf: $nbf,
+            actor: $actor,
+            org: $org,
+            wasTest: isset($claims['was_test']) && $claims['was_test'] === true,
+            raw: $claims,
+        );
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $act
+     * @return array{iss: string, sub: string, sid: string}|null
+     */
+    private function normalizeActor(array $act): ?array
+    {
+        $iss = isset($act['iss']) && is_string($act['iss']) ? $act['iss'] : null;
+        $sub = isset($act['sub']) && is_string($act['sub']) ? $act['sub'] : null;
+        $sid = isset($act['sid']) && is_string($act['sid']) ? $act['sid'] : null;
+        if ($iss === null || $sub === null || $sid === null) {
+            return null;
+        }
+
+        return ['iss' => $iss, 'sub' => $sub, 'sid' => $sid];
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $org
+     * @return array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null
+     */
+    private function normalizeOrg(array $org): ?array
+    {
+        $id = isset($org['id']) && is_string($org['id']) ? $org['id'] : null;
+        if ($id === null) {
+            return null;
+        }
+
+        $out = ['id' => $id];
+        if (isset($org['slg']) && is_string($org['slg'])) {
+            $out['slg'] = $org['slg'];
+        }
+        if (isset($org['rol']) && is_string($org['rol'])) {
+            $out['rol'] = $org['rol'];
+        }
+        if (isset($org['per']) && is_array($org['per'])) {
+            $perms = [];
+            foreach ($org['per'] as $p) {
+                if (is_string($p)) {
+                    $perms[] = $p;
+                }
+            }
+            $out['per'] = $perms;
+        }
+
+        return $out;
+    }
+
+    private function cacheKey(): string
+    {
+        return 'authn.jwks.' . hash('sha256', $this->frontendApiUrl);
+    }
+}

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tokens;
+
+final class VerifiedClaims
+{
+    /**
+     * @param  array{iss: string, sub: string, sid: string}|null  $actor  impersonation chain
+     * @param  array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null  $org  v0.2 organization claims
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $sub,
+        public readonly string $sid,
+        public readonly string $iss,
+        public readonly ?string $azp,
+        public readonly int $exp,
+        public readonly int $iat,
+        public readonly ?int $nbf,
+        public readonly ?array $actor,
+        public readonly ?array $org,
+        public readonly bool $wasTest,
+        public readonly array $raw,
+    ) {}
+}

--- a/src/Util/PublishableKey.php
+++ b/src/Util/PublishableKey.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Util;
+
+use InvalidArgumentException;
+
+/**
+ * Helpers for the `pk_test_…` / `pk_live_…` publishable key format.
+ *
+ * The suffix after `pk_(test|live)_` is the base64url-encoded Frontend API host
+ * with a trailing `$` character (used as a basic validity marker).
+ */
+final class PublishableKey
+{
+    public static function frontendApiUrl(string $publishableKey): string
+    {
+        if (! preg_match('/^pk_(test|live)_([A-Za-z0-9_-]+)$/', $publishableKey, $m)) {
+            throw new InvalidArgumentException('Malformed publishable key: expected pk_test_… or pk_live_…');
+        }
+
+        $encoded = strtr($m[2], '-_', '+/');
+        $padding = strlen($encoded) % 4;
+        if ($padding > 0) {
+            $encoded .= str_repeat('=', 4 - $padding);
+        }
+
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false) {
+            throw new InvalidArgumentException('Malformed publishable key: suffix is not valid base64url.');
+        }
+
+        $host = rtrim($decoded, '$');
+        if ($host === '') {
+            throw new InvalidArgumentException('Malformed publishable key: empty Frontend API host.');
+        }
+
+        return 'https://' . $host;
+    }
+
+    public static function isTestKey(string $publishableKey): bool
+    {
+        return str_starts_with($publishableKey, 'pk_test_');
+    }
+}

--- a/src/Webhooks/SignatureInvalidException.php
+++ b/src/Webhooks/SignatureInvalidException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Webhooks;
+
+use RuntimeException;
+
+final class SignatureInvalidException extends RuntimeException {}

--- a/src/Webhooks/SignatureVerifier.php
+++ b/src/Webhooks/SignatureVerifier.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Webhooks;
+
+use Authn\Sdk\Util\Json;
+
+/**
+ * Verifies authn.sh webhook signatures (svix-compatible scheme).
+ *
+ * The transport signs `{svix-id}.{svix-timestamp}.{rawBody}` with HMAC-SHA256
+ * keyed by the `whsec_…` signing secret. Multiple secrets can be supplied to
+ * tolerate key rotation: a request is accepted if any provided signature
+ * matches any configured secret.
+ */
+final class SignatureVerifier
+{
+    /** @var list<string> */
+    private readonly array $signingSecrets;
+
+    /**
+     * @param  string|list<string>  $signingSecret  one or more `whsec_…` secrets (rotation overlap)
+     */
+    public function __construct(
+        string|array $signingSecret,
+        private readonly int $toleranceSeconds = 300,
+    ) {
+        $this->signingSecrets = is_array($signingSecret)
+            ? array_values(array_filter($signingSecret, static fn ($s): bool => $s !== ''))
+            : [$signingSecret];
+
+        if ($this->signingSecrets === []) {
+            throw new \InvalidArgumentException('At least one signing secret must be provided.');
+        }
+    }
+
+    /**
+     * @param  array<string, string|list<string>>  $headers  case-insensitive
+     *
+     * @throws SignatureInvalidException
+     */
+    public function verify(string $rawBody, array $headers): WebhookEvent
+    {
+        $id = $this->headerLine($headers, 'svix-id');
+        $timestamp = $this->headerLine($headers, 'svix-timestamp');
+        $signature = $this->headerLine($headers, 'svix-signature');
+
+        if ($id === null || $timestamp === null || $signature === null) {
+            throw new SignatureInvalidException('Missing svix-id, svix-timestamp, or svix-signature header.');
+        }
+
+        if (! ctype_digit($timestamp)) {
+            throw new SignatureInvalidException('svix-timestamp must be a unix-second integer.');
+        }
+        $tsInt = (int) $timestamp;
+
+        if (abs(time() - $tsInt) > $this->toleranceSeconds) {
+            throw new SignatureInvalidException('Webhook timestamp is outside the tolerance window.');
+        }
+
+        $signedPayload = "{$id}.{$timestamp}.{$rawBody}";
+        $providedSignatures = $this->extractV1Signatures($signature);
+
+        if ($providedSignatures === []) {
+            throw new SignatureInvalidException('No v1 signatures found in svix-signature header.');
+        }
+
+        if (! $this->matchesAny($signedPayload, $providedSignatures)) {
+            throw new SignatureInvalidException('Webhook signature does not match.');
+        }
+
+        $payload = Json::decode($rawBody);
+        if ($payload === []) {
+            throw new SignatureInvalidException('Webhook body is not a JSON object.');
+        }
+
+        $type = isset($payload['type']) && is_string($payload['type']) ? $payload['type'] : '';
+        $data = isset($payload['data']) && is_array($payload['data']) ? $payload['data'] : [];
+        $instanceId = isset($payload['instance_id']) && is_string($payload['instance_id']) ? $payload['instance_id'] : '';
+        $wasTest = isset($payload['was_test']) && $payload['was_test'] === true;
+
+        /** @var array<string, mixed> $data */
+        return new WebhookEvent(
+            type: $type,
+            data: $data,
+            timestamp: $tsInt * 1000,
+            instanceId: $instanceId,
+            wasTest: $wasTest,
+            messageId: $id,
+        );
+    }
+
+    /**
+     * @param  array<string, string|list<string>>  $headers
+     */
+    public function tryVerify(string $rawBody, array $headers): ?WebhookEvent
+    {
+        try {
+            return $this->verify($rawBody, $headers);
+        } catch (SignatureInvalidException) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<string, string|list<string>>  $headers
+     */
+    private function headerLine(array $headers, string $name): ?string
+    {
+        foreach ($headers as $header => $value) {
+            if (strcasecmp($header, $name) !== 0) {
+                continue;
+            }
+            if (is_array($value)) {
+                $value = $value === [] ? null : (string) $value[0];
+            }
+
+            return $value === null || $value === '' ? null : (string) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractV1Signatures(string $header): array
+    {
+        $out = [];
+        foreach (preg_split('/\s+/', trim($header)) ?: [] as $entry) {
+            if ($entry === '' || ! str_starts_with($entry, 'v1,')) {
+                continue;
+            }
+            $sig = substr($entry, 3);
+            if ($sig !== '') {
+                $out[] = $sig;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  list<string>  $providedBase64
+     */
+    private function matchesAny(string $signedPayload, array $providedBase64): bool
+    {
+        foreach ($this->signingSecrets as $secret) {
+            $rawSecret = $this->decodeSecret($secret);
+            $expected = base64_encode(hash_hmac('sha256', $signedPayload, $rawSecret, true));
+            foreach ($providedBase64 as $provided) {
+                if (hash_equals($expected, $provided)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function decodeSecret(string $secret): string
+    {
+        if (str_starts_with($secret, 'whsec_')) {
+            $b64 = substr($secret, strlen('whsec_'));
+            $decoded = base64_decode($b64, true);
+            if ($decoded !== false) {
+                return $decoded;
+            }
+        }
+
+        return $secret;
+    }
+}

--- a/src/Webhooks/WebhookEvent.php
+++ b/src/Webhooks/WebhookEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Webhooks;
+
+final class WebhookEvent
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly array $data,
+        public readonly int $timestamp,
+        public readonly string $instanceId,
+        public readonly bool $wasTest,
+        public readonly string $messageId,
+    ) {}
+}

--- a/tests/Support/JwtFixture.php
+++ b/tests/Support/JwtFixture.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tests\Support;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+
+/**
+ * Test helper: generates a fresh RSA keypair, can sign JWTs against it, and
+ * exposes the matching JWKS document for the verifier to consume.
+ */
+final class JwtFixture
+{
+    public readonly JWK $jwk;
+
+    public readonly string $kid;
+
+    public function __construct(string $kid = 'test-kid-1')
+    {
+        $this->kid = $kid;
+        $this->jwk = JWKFactory::createRSAKey(2048, [
+            'alg' => 'RS256',
+            'use' => 'sig',
+            'kid' => $kid,
+        ]);
+    }
+
+    public function jwksJson(): string
+    {
+        $jwks = new JWKSet([$this->jwk->toPublic()]);
+
+        return json_encode($jwks, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     * @param  array<string, mixed>  $headerOverrides
+     */
+    public function sign(array $claims, array $headerOverrides = []): string
+    {
+        $builder = new JWSBuilder(new AlgorithmManager([new RS256]));
+        $header = array_merge(
+            ['alg' => 'RS256', 'typ' => 'JWT', 'kid' => $this->kid],
+            $headerOverrides,
+        );
+
+        $jws = $builder
+            ->create()
+            ->withPayload(json_encode($claims, JSON_THROW_ON_ERROR))
+            ->addSignature($this->jwk, $header)
+            ->build();
+
+        return (new CompactSerializer)->serialize($jws);
+    }
+}

--- a/tests/Support/MemoryCache.php
+++ b/tests/Support/MemoryCache.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tests\Support;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+final class MemoryCache implements CacheInterface
+{
+    /** @var array<string, array{value: mixed, expiresAt: int|null}> */
+    private array $store = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (! $this->has($key)) {
+            return $default;
+        }
+
+        return $this->store[$key]['value'];
+    }
+
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    {
+        $expiresAt = null;
+        if (is_int($ttl)) {
+            $expiresAt = time() + $ttl;
+        } elseif ($ttl instanceof DateInterval) {
+            $expiresAt = (new \DateTimeImmutable)->add($ttl)->getTimestamp();
+        }
+
+        $this->store[$key] = ['value' => $value, 'expiresAt' => $expiresAt];
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->store[$key]);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->store = [];
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     * @return iterable<string, mixed>
+     */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $out = [];
+        foreach ($keys as $key) {
+            $out[$key] = $this->get($key, $default);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  iterable<string, mixed>  $values
+     */
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  iterable<string>  $keys
+     */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        if (! isset($this->store[$key])) {
+            return false;
+        }
+
+        $expiresAt = $this->store[$key]['expiresAt'];
+        if ($expiresAt !== null && $expiresAt < time()) {
+            unset($this->store[$key]);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Support/StaticBodyClient.php
+++ b/tests/Support/StaticBodyClient.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tests\Support;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Tiny PSR-18 client that returns a queued body for a queued status, counting calls.
+ *
+ * Built specifically for JWKS-fetch tests where we need to count how many times
+ * the SDK hit the JWKS endpoint and swap the response between calls.
+ */
+final class StaticBodyClient implements ClientInterface
+{
+    public int $calls = 0;
+
+    /** @var list<string|null> */
+    public array $bodies;
+
+    public function __construct(?string ...$bodies)
+    {
+        $this->bodies = $bodies === [] ? [null] : array_values($bodies);
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $idx = min($this->calls, count($this->bodies) - 1);
+        $body = $this->bodies[$idx];
+        $this->calls++;
+
+        $factory = new Psr17Factory;
+        $response = $factory->createResponse($body === null ? 500 : 200)
+            ->withHeader('Content-Type', 'application/json');
+        if ($body !== null) {
+            $response = $response->withBody($factory->createStream($body));
+        }
+
+        return $response;
+    }
+}

--- a/tests/Tokens/PublishableKeyTest.php
+++ b/tests/Tokens/PublishableKeyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Util\PublishableKey;
+
+it('round-trips host through the publishable-key encoding', function (): void {
+    $host = 'magnetic-zebra-42.authn.sh';
+    $b64 = rtrim(strtr(base64_encode($host . '$'), '+/', '-_'), '=');
+    $key = "pk_test_{$b64}";
+
+    expect(PublishableKey::frontendApiUrl($key))->toBe('https://' . $host);
+    expect(PublishableKey::isTestKey($key))->toBeTrue();
+});
+
+it('decodes a live key', function (): void {
+    $b64 = rtrim(strtr(base64_encode('acme.authn.sh$'), '+/', '-_'), '=');
+    $key = "pk_live_{$b64}";
+
+    expect(PublishableKey::frontendApiUrl($key))->toBe('https://acme.authn.sh');
+    expect(PublishableKey::isTestKey($key))->toBeFalse();
+});
+
+it('rejects malformed keys', function (): void {
+    expect(fn () => PublishableKey::frontendApiUrl('garbage'))->toThrow(InvalidArgumentException::class);
+    expect(fn () => PublishableKey::frontendApiUrl('pk_test_'))->toThrow(InvalidArgumentException::class);
+    expect(fn () => PublishableKey::frontendApiUrl('pk_test_!!!!'))->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Tests\Support\JwtFixture;
+use Authn\Sdk\Tests\Support\MemoryCache;
+use Authn\Sdk\Tests\Support\StaticBodyClient;
+use Authn\Sdk\Tokens\TokenInvalidException;
+use Authn\Sdk\Tokens\TokenVerifier;
+
+function makeVerifier(
+    StaticBodyClient $http,
+    ?MemoryCache $cache = null,
+    int $skew = 5,
+    int $ttl = 600,
+): TokenVerifier {
+    return new TokenVerifier(
+        publishableKey: 'pk_test_dummy',
+        frontendApiUrl: 'https://acme.authn.sh',
+        cache: $cache ?? new MemoryCache,
+        http: $http,
+        jwksCacheTtlSeconds: $ttl,
+        allowedClockSkewSeconds: $skew,
+    );
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function validClaims(): array
+{
+    $now = time();
+
+    return [
+        'iss' => 'https://acme.authn.sh',
+        'sub' => 'user_2x',
+        'sid' => 'sess_1y',
+        'azp' => 'https://app.example',
+        'iat' => $now - 1,
+        'exp' => $now + 3600,
+        'nbf' => $now - 5,
+        'was_test' => true,
+    ];
+}
+
+it('verifies a well-formed JWT and returns parsed claims', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+    $jwt = $fixture->sign(validClaims());
+
+    $claims = $verifier->verify($jwt);
+
+    expect($claims->sub)->toBe('user_2x');
+    expect($claims->sid)->toBe('sess_1y');
+    expect($claims->iss)->toBe('https://acme.authn.sh');
+    expect($claims->azp)->toBe('https://app.example');
+    expect($claims->wasTest)->toBeTrue();
+    expect($claims->raw['was_test'])->toBeTrue();
+});
+
+it('caches the JWKS for the configured TTL (one fetch across many verifies)', function (): void {
+    $fixture = new JwtFixture;
+    $http = new StaticBodyClient($fixture->jwksJson());
+    $verifier = makeVerifier($http, new MemoryCache);
+
+    for ($i = 0; $i < 5; $i++) {
+        $verifier->verify($fixture->sign(validClaims()));
+    }
+
+    expect($http->calls)->toBe(1);
+});
+
+it('refreshes JWKS once on unknown kid; success when the new doc carries it', function (): void {
+    $oldFixture = new JwtFixture('old-kid');
+    $newFixture = new JwtFixture('new-kid');
+
+    $http = new StaticBodyClient($oldFixture->jwksJson(), $newFixture->jwksJson());
+    $cache = new MemoryCache;
+    $verifier = makeVerifier($http, $cache);
+
+    $verifier->verify($oldFixture->sign(validClaims()));
+    expect($http->calls)->toBe(1);
+
+    $jwtFromNew = $newFixture->sign(validClaims());
+    $claims = $verifier->verify($jwtFromNew);
+
+    expect($claims->sub)->toBe('user_2x');
+    expect($http->calls)->toBe(2);
+});
+
+it('throws TokenInvalidException when kid stays unknown after refresh', function (): void {
+    $serverFixture = new JwtFixture('server-kid');
+    $strangerFixture = new JwtFixture('stranger-kid');
+
+    $cache = new MemoryCache;
+    $http = new StaticBodyClient($serverFixture->jwksJson(), $serverFixture->jwksJson());
+    $verifier = makeVerifier($http, $cache);
+
+    // Warm the cache with a successful verify, so the next call sees a cache hit.
+    $verifier->verify($serverFixture->sign(validClaims()));
+    expect($http->calls)->toBe(1);
+
+    // Now an unknown kid must trigger exactly one refresh (call #2) before failing.
+    expect(fn () => $verifier->verify($strangerFixture->sign(validClaims())))
+        ->toThrow(TokenInvalidException::class);
+    expect($http->calls)->toBe(2);
+});
+
+it('rejects an expired JWT', function (): void {
+    $fixture = new JwtFixture;
+    $http = new StaticBodyClient($fixture->jwksJson());
+    $verifier = makeVerifier($http);
+
+    $claims = validClaims();
+    $claims['exp'] = time() - 60;
+    $claims['iat'] = time() - 120;
+
+    expect(fn () => $verifier->verify($fixture->sign($claims)))->toThrow(TokenInvalidException::class);
+});
+
+it('rejects a JWT whose iss does not match the FAPI URL', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['iss'] = 'https://impostor.authn.sh';
+
+    expect(fn () => $verifier->verify($fixture->sign($claims)))->toThrow(TokenInvalidException::class);
+});
+
+it('rejects a JWT with a bad signature', function (): void {
+    $serverFixture = new JwtFixture;
+    $attackerFixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($serverFixture->jwksJson()));
+
+    $jwt = $attackerFixture->sign(validClaims(), headerOverrides: ['kid' => $serverFixture->kid]);
+
+    expect(fn () => $verifier->verify($jwt))->toThrow(TokenInvalidException::class);
+});
+
+it('enforces expectedAzp when the caller passes it', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+    $jwt = $fixture->sign(validClaims());
+
+    expect($verifier->verify($jwt, ['https://app.example']))->not->toBeNull();
+    expect(fn () => $verifier->verify($jwt, ['https://wrong.example']))
+        ->toThrow(TokenInvalidException::class);
+});
+
+it('tryVerify returns null on failure instead of throwing', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    expect($verifier->tryVerify('not.a.jwt'))->toBeNull();
+});
+
+it('rejects malformed JWTs with TokenInvalidException', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    expect(fn () => $verifier->verify('definitely.not.a.jwt'))->toThrow(TokenInvalidException::class);
+});
+
+it('parses actor and org claims when present', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['act'] = ['iss' => 'https://acme.authn.sh', 'sub' => 'user_admin', 'sid' => 'sess_admin'];
+    $claims['org'] = ['id' => 'org_1', 'slg' => 'acme', 'rol' => 'admin', 'per' => ['users:read', 'users:write']];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->actor)->toBe(['iss' => 'https://acme.authn.sh', 'sub' => 'user_admin', 'sid' => 'sess_admin']);
+    $org = $verified->org;
+    expect($org)->not->toBeNull();
+    expect($org)->toMatchArray(['id' => 'org_1', 'slg' => 'acme', 'rol' => 'admin']);
+    expect($org['per'] ?? null)->toBe(['users:read', 'users:write']);
+});

--- a/tests/Webhooks/SignatureVerifierTest.php
+++ b/tests/Webhooks/SignatureVerifierTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Webhooks\SignatureInvalidException;
+use Authn\Sdk\Webhooks\SignatureVerifier;
+
+function makeWhSecret(string $rawSecret = 'this-is-a-32-byte-random-secret!'): string
+{
+    return 'whsec_' . base64_encode($rawSecret);
+}
+
+function signWebhook(
+    string $rawSecret,
+    string $messageId,
+    int $timestamp,
+    string $body,
+): string {
+    $signedPayload = "{$messageId}.{$timestamp}.{$body}";
+    $signature = base64_encode(hash_hmac('sha256', $signedPayload, $rawSecret, true));
+
+    return "v1,{$signature}";
+}
+
+/**
+ * @return array<string, string>
+ */
+function webhookHeaders(string $messageId, int $timestamp, string $signature): array
+{
+    return [
+        'svix-id' => $messageId,
+        'svix-timestamp' => (string) $timestamp,
+        'svix-signature' => $signature,
+    ];
+}
+
+it('verifies a valid signature and returns a parsed event', function (): void {
+    $rawSecret = 'r4ndom-secret-bytes';
+    $verifier = new SignatureVerifier(makeWhSecret($rawSecret));
+
+    $now = time();
+    $body = json_encode([
+        'type' => 'user.created',
+        'data' => ['id' => 'user_1', 'email_address' => 'a@b.com'],
+        'instance_id' => 'env_acme_test',
+        'was_test' => true,
+    ], JSON_THROW_ON_ERROR);
+
+    $headers = webhookHeaders('msg_1', $now, signWebhook($rawSecret, 'msg_1', $now, $body));
+
+    $event = $verifier->verify($body, $headers);
+
+    expect($event->type)->toBe('user.created');
+    expect($event->data)->toMatchArray(['id' => 'user_1']);
+    expect($event->instanceId)->toBe('env_acme_test');
+    expect($event->wasTest)->toBeTrue();
+    expect($event->messageId)->toBe('msg_1');
+    expect($event->timestamp)->toBe($now * 1000);
+});
+
+it('rejects a tampered body', function (): void {
+    $rawSecret = 'shared';
+    $verifier = new SignatureVerifier(makeWhSecret($rawSecret));
+
+    $now = time();
+    $body = '{"type":"user.created","data":{"id":"user_1"}}';
+    $headers = webhookHeaders('msg_1', $now, signWebhook($rawSecret, 'msg_1', $now, $body));
+
+    $tampered = str_replace('user_1', 'user_2', $body);
+
+    expect(fn () => $verifier->verify($tampered, $headers))->toThrow(SignatureInvalidException::class);
+});
+
+it('rejects timestamps outside the tolerance window (replay protection)', function (): void {
+    $rawSecret = 'shared';
+    $verifier = new SignatureVerifier(makeWhSecret($rawSecret), toleranceSeconds: 60);
+
+    $oldTs = time() - 600;
+    $body = '{"type":"x","data":{}}';
+    $headers = webhookHeaders('msg_1', $oldTs, signWebhook($rawSecret, 'msg_1', $oldTs, $body));
+
+    expect(fn () => $verifier->verify($body, $headers))->toThrow(SignatureInvalidException::class);
+});
+
+it('accepts either secret during a rotation overlap window', function (): void {
+    $oldSecret = 'old-secret';
+    $newSecret = 'new-secret';
+    $verifier = new SignatureVerifier([makeWhSecret($oldSecret), makeWhSecret($newSecret)]);
+
+    $now = time();
+    $body = '{"type":"x","data":{}}';
+
+    $signedByOld = signWebhook($oldSecret, 'msg_1', $now, $body);
+    $signedByNew = signWebhook($newSecret, 'msg_2', $now, $body);
+
+    expect($verifier->verify($body, webhookHeaders('msg_1', $now, $signedByOld))->messageId)->toBe('msg_1');
+    expect($verifier->verify($body, webhookHeaders('msg_2', $now, $signedByNew))->messageId)->toBe('msg_2');
+});
+
+it('accepts a multi-version signature header (rotation)', function (): void {
+    $oldSecret = 'old-secret';
+    $newSecret = 'new-secret';
+    $verifier = new SignatureVerifier(makeWhSecret($newSecret));
+
+    $now = time();
+    $body = '{"type":"x","data":{}}';
+    $oldSig = signWebhook($oldSecret, 'msg_3', $now, $body);
+    $newSig = signWebhook($newSecret, 'msg_3', $now, $body);
+    $combined = "{$oldSig} {$newSig}";
+
+    expect($verifier->verify($body, webhookHeaders('msg_3', $now, $combined))->type)->toBe('x');
+});
+
+it('rejects requests with missing or empty headers', function (): void {
+    $verifier = new SignatureVerifier(makeWhSecret('s'));
+
+    expect(fn () => $verifier->verify('{}', []))->toThrow(SignatureInvalidException::class);
+    expect(fn () => $verifier->verify('{}', ['svix-id' => 'x', 'svix-timestamp' => '1']))
+        ->toThrow(SignatureInvalidException::class);
+});
+
+it('rejects non-numeric timestamps', function (): void {
+    $verifier = new SignatureVerifier(makeWhSecret('s'));
+
+    expect(fn () => $verifier->verify('{}', webhookHeaders('msg', 0, 'v1,xx') + ['svix-timestamp' => 'not-a-time']))
+        ->toThrow(SignatureInvalidException::class);
+});
+
+it('rejects empty / non-v1 signatures', function (): void {
+    $verifier = new SignatureVerifier(makeWhSecret('s'));
+
+    expect(fn () => $verifier->verify('{}', webhookHeaders('msg', time(), 'v2,abc')))
+        ->toThrow(SignatureInvalidException::class);
+});
+
+it('tryVerify swallows SignatureInvalidException and returns null', function (): void {
+    $verifier = new SignatureVerifier(makeWhSecret('s'));
+
+    expect($verifier->tryVerify('{}', []))->toBeNull();
+});
+
+it('reads svix headers case-insensitively and accepts header arrays', function (): void {
+    $rawSecret = 'shared';
+    $verifier = new SignatureVerifier(makeWhSecret($rawSecret));
+
+    $now = time();
+    $body = '{"type":"x","data":{}}';
+    $sig = signWebhook($rawSecret, 'msg_1', $now, $body);
+
+    $headers = [
+        'Svix-Id' => 'msg_1',
+        'Svix-Timestamp' => [(string) $now],
+        'Svix-Signature' => $sig,
+    ];
+
+    expect($verifier->verify($body, $headers)->messageId)->toBe('msg_1');
+});
+
+it('falls back to the raw secret when the input is not whsec-prefixed', function (): void {
+    $rawSecret = 'plain-shared-secret';
+    $verifier = new SignatureVerifier($rawSecret);
+
+    $now = time();
+    $body = '{"type":"x","data":{}}';
+    $sig = signWebhook($rawSecret, 'msg_1', $now, $body);
+
+    expect($verifier->verify($body, webhookHeaders('msg_1', $now, $sig))->type)->toBe('x');
+});


### PR DESCRIPTION
## Summary

Implements [SP-3](https://github.com/authn-sh/sdk-php/issues/3) — the **request-side** of `sdk-php`: verifying that an incoming session JWT is valid, and that an incoming webhook actually came from authn.sh.

> **Scope change:** the Laravel package layer originally bundled into SP-3 has been **deferred to a separate `authn-sh/sdk-php-laravel` repo** so this core package stays framework-agnostic. The `extra.laravel.providers` line is removed from `composer.json` here.

## What's in

### JWT verifier — `Authn\Sdk\Tokens\TokenVerifier`

- Fetches `/.well-known/jwks.json` from the Frontend API (host derived from the publishable key, or overridable explicitly).
- Caches the JWKS in PSR-16 for `jwksCacheTtlSeconds` (default 600s); unknown `kid` → refresh once, then fail.
- Validates `exp` / `nbf` / `iat` with `allowedClockSkewSeconds`, `iss` against the configured FAPI URL, and (optionally) `azp` against an `expectedAzp[]` allowlist.
- Returns an immutable `VerifiedClaims` value object: `sub`, `sid`, `iss`, `azp`, `exp` / `iat` / `nbf`, `actor` (impersonation), `org` (v0.2), `wasTest`, and `raw`.
- `verify()` throws `TokenInvalidException`; `tryVerify()` returns `null`.
- RS256 / ES256 / ES384 / ES512 supported.
- Ships with a no-op `Authn\Sdk\Cache\NullCache` so the verifier works without a cache (every verify will refetch JWKS).
- New `Authn\Sdk\Util\PublishableKey` helper decodes `pk_(test|live)_<base64url>` → Frontend API URL.

### Webhook verifier — `Authn\Sdk\Webhooks\SignatureVerifier`

- Reads `svix-id` / `svix-timestamp` / `svix-signature` headers (case-insensitive, accepts header arrays).
- Recomputes `HMAC-SHA256(secret, '{id}.{ts}.{rawBody}')` and constant-time compares against each `v1,<sig>` entry.
- Replay protection: rejects timestamps outside `toleranceSeconds` (default 300).
- **Multi-secret rotation:** constructor accepts `string|list<string>`, so old + new signing secrets can both be honored during overlap.
- Returns an immutable `WebhookEvent` (`type`, `data`, `timestamp` in ms, `instanceId`, `wasTest`, `messageId`).
- `verify()` throws `SignatureInvalidException`; `tryVerify()` returns `null`.

### Composer / packaging

- `psr/simple-cache: ^3.0` added to `require`.
- `extra.laravel.providers` removed (Laravel package will land in `authn-sh/sdk-php-laravel`).
- Package description updated.

## Tests

25 new Pest tests covering JWT happy path, JWKS cache hit, unknown-kid refresh (success + stays-unknown), expired, bad signature, iss mismatch, expectedAzp enforcement, malformed JWT, actor/org claims; webhook valid/tampered/replay, multi-secret rotation, multi-version signature header, missing headers, non-numeric timestamps, non-v1 signatures, case-insensitive headers, raw-secret fallback; `PublishableKey` decoder round-trip + malformed-key rejection.

**Final: 75 pass, 1 skipped, 204 assertions.** PHPStan @ level 10 clean. Pint clean.

## Test plan

- [x] `composer test` — 75 pass, 1 skipped (contract test, OA-2/3/4 pending)
- [x] `composer phpstan` — clean
- [x] `composer pint` — clean
- [ ] CI green on PHP 8.2 / 8.3 / 8.4 / 8.5

## Out of scope (deferred)

- Laravel ServiceProvider, middleware, Blade directives, facade — moves to `authn-sh/sdk-php-laravel`.
- Async/parallel verify — out of scope.

Closes #3