### PR TITLE
Activate contract test against the v0.1 OpenAPI bundle

### DIFF
--- a/tests/ContractTest.php
+++ b/tests/ContractTest.php
@@ -61,9 +61,19 @@ it('declares operations for every BAPI endpoint the SDK calls', function (): voi
         ['PATCH', '/v1/instance/restrictions'],
     ];
 
+    $missing = [];
     foreach ($expected as [$method, $path]) {
-        expect($paths)->toHaveKey($path, "Expected path {$path} to be documented in the OpenAPI spec.");
-        $verbs = is_array($paths[$path] ?? null) ? array_change_key_case($paths[$path], CASE_LOWER) : [];
-        expect($verbs)->toHaveKey(strtolower($method), "Expected {$method} on {$path}.");
+        $pathItem = $paths[$path] ?? null;
+        if (! is_array($pathItem)) {
+            $missing[] = "path {$path}";
+
+            continue;
+        }
+        $verbs = array_change_key_case($pathItem, CASE_LOWER);
+        if (! array_key_exists(strtolower($method), $verbs)) {
+            $missing[] = "{$method} on {$path}";
+        }
     }
+
+    expect($missing)->toBe([], 'Missing from OpenAPI spec: ' . implode(', ', $missing));
 });

--- a/tests/fixtures/openapi.bundled.json
+++ b/tests/fixtures/openapi.bundled.json
@@ -114,7 +114,5752 @@
       "description": "Public keys and OIDC discovery served per-environment on the FAPI host."
     }
   ],
-  "paths": {},
+  "paths": {
+    "/v1/users": {
+      "get": {
+        "operationId": "listUsers",
+        "summary": "List users",
+        "description": "Return a paginated list of users in the environment, filtered by\nidentifier and lifecycle predicates.\n",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "Sort key prefixed with `+` (ascending, default) or `-` (descending).\nAllowed: `created_at`, `updated_at`, `last_active_at`, `last_sign_in_at`.\n",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "+created_at",
+                "-last_active_at"
+              ]
+            }
+          },
+          {
+            "name": "email_address",
+            "in": "query",
+            "description": "Filter by email address. Repeat the parameter for OR semantics.\n",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          },
+          {
+            "name": "phone_number",
+            "in": "query",
+            "description": "Filter by phone number (E.164). v0.1 always returns an empty\nlist since phone identifiers ship in v0.4.\n",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "Filter by username. Repeat for OR semantics.",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Filter by `User.id`. Repeat for OR semantics.",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "external_id",
+            "in": "query",
+            "description": "Filter by `User.external_id`. Repeat for OR semantics.",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Free-text search across email addresses, usernames, first\nname, last name. Case-insensitive substring match.\n",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "last_active_at_since",
+            "in": "query",
+            "description": "Unix ms; only return users active at or after this instant.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "created_at_after",
+            "in": "query",
+            "description": "Unix ms; only return users created strictly after this instant.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "created_at_before",
+            "in": "query",
+            "description": "Unix ms; only return users created strictly before this instant.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of users.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/User"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "page": {
+                    "summary": "First page, two users",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                          "object": "user",
+                          "external_id": null,
+                          "username": "jane",
+                          "first_name": "Jane",
+                          "last_name": "Doe",
+                          "image_url": null,
+                          "has_image": false,
+                          "primary_email_address_id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                          "primary_phone_number_id": null,
+                          "email_addresses": [
+                            {
+                              "id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                              "object": "email_address",
+                              "email_address": "jane@acme.com",
+                              "verification": {
+                                "status": "verified",
+                                "strategy": "email_code",
+                                "attempts": 1,
+                                "expire_at": null,
+                                "external_verification_redirect_url": null,
+                                "nonce": null,
+                                "error": null
+                              },
+                              "linked_to": [],
+                              "reserved": false,
+                              "created_at": 1714723200000,
+                              "updated_at": 1714723260000
+                            }
+                          ],
+                          "phone_numbers": [],
+                          "external_accounts": [],
+                          "enterprise_accounts": [],
+                          "passkeys": [],
+                          "password_enabled": true,
+                          "two_factor_enabled": false,
+                          "totp_enabled": false,
+                          "backup_code_enabled": false,
+                          "mfa_enabled_at": null,
+                          "mfa_disabled_at": null,
+                          "banned": false,
+                          "locked": false,
+                          "lockout_expires_at": null,
+                          "last_sign_in_at": 1714809600000,
+                          "last_active_at": 1714895999000,
+                          "delete_self_enabled": true,
+                          "locale": "en-US",
+                          "public_metadata": {
+                            "plan": "pro"
+                          },
+                          "private_metadata": {},
+                          "unsafe_metadata": {},
+                          "created_at": 1714723200000,
+                          "updated_at": 1714895999000
+                        }
+                      ],
+                      "total_count": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createUser",
+        "summary": "Create a user",
+        "description": "Create a `User`. The BAPI is privileged: identifiers passed in\n`email_address[]` are created already verified, and `password`\nbypasses the user-flow verification step. At least one of\n`email_address`, `phone_number`, `username`, or `external_id`\nmust be supplied.\n",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreateRequest"
+              },
+              "examples": {
+                "basic": {
+                  "summary": "Create with email + password",
+                  "value": {
+                    "email_address": [
+                      "jane@acme.com"
+                    ],
+                    "password": "correct horse battery staple",
+                    "first_name": "Jane",
+                    "last_name": "Doe",
+                    "public_metadata": {
+                      "plan": "pro"
+                    }
+                  }
+                },
+                "migration": {
+                  "summary": "Migrate a pre-hashed password",
+                  "value": {
+                    "external_id": "legacy-user-42",
+                    "email_address": [
+                      "jane@acme.com"
+                    ],
+                    "password_digest": "$2a$10$N9qo8uLOickgx2ZMRZoMye…",
+                    "password_hasher": "bcrypt",
+                    "created_at": 1577836800000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "created": {
+                    "summary": "Newly-created user",
+                    "value": {
+                      "id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                      "object": "user",
+                      "external_id": null,
+                      "username": null,
+                      "first_name": "Jane",
+                      "last_name": "Doe",
+                      "image_url": null,
+                      "has_image": false,
+                      "primary_email_address_id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                      "primary_phone_number_id": null,
+                      "email_addresses": [
+                        {
+                          "id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                          "object": "email_address",
+                          "email_address": "jane@acme.com",
+                          "verification": {
+                            "status": "verified",
+                            "strategy": "email_code",
+                            "attempts": 0,
+                            "expire_at": null,
+                            "external_verification_redirect_url": null,
+                            "nonce": null,
+                            "error": null
+                          },
+                          "linked_to": [],
+                          "reserved": false,
+                          "created_at": 1714723200000,
+                          "updated_at": 1714723200000
+                        }
+                      ],
+                      "phone_numbers": [],
+                      "external_accounts": [],
+                      "enterprise_accounts": [],
+                      "passkeys": [],
+                      "password_enabled": true,
+                      "two_factor_enabled": false,
+                      "totp_enabled": false,
+                      "backup_code_enabled": false,
+                      "mfa_enabled_at": null,
+                      "mfa_disabled_at": null,
+                      "banned": false,
+                      "locked": false,
+                      "lockout_expires_at": null,
+                      "last_sign_in_at": null,
+                      "last_active_at": null,
+                      "delete_self_enabled": true,
+                      "locale": null,
+                      "public_metadata": {
+                        "plan": "pro"
+                      },
+                      "private_metadata": {},
+                      "unsafe_metadata": {},
+                      "created_at": 1714723200000,
+                      "updated_at": 1714723200000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/users/count": {
+      "get": {
+        "operationId": "countUsers",
+        "summary": "Count users",
+        "description": "Return the total number of users matching the same filter set as\n`listUsers`. Useful for pagination headers and dashboards.\n",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "name": "email_address",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          },
+          {
+            "name": "phone_number",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "external_id",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "last_active_at_since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "created_at_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "created_at_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Total count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "total_count"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "total_count"
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    }
+                  }
+                },
+                "examples": {
+                  "count": {
+                    "value": {
+                      "object": "total_count",
+                      "total_count": 12345
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "description": "ID of the user.",
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUser",
+        "summary": "Get a user",
+        "description": "Fetch a single `User` by ID.",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "user": {
+                    "value": {
+                      "id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                      "object": "user",
+                      "external_id": null,
+                      "username": "jane",
+                      "first_name": "Jane",
+                      "last_name": "Doe",
+                      "image_url": null,
+                      "has_image": false,
+                      "primary_email_address_id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                      "primary_phone_number_id": null,
+                      "email_addresses": [
+                        {
+                          "id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                          "object": "email_address",
+                          "email_address": "jane@acme.com",
+                          "verification": {
+                            "status": "verified",
+                            "strategy": "email_code",
+                            "attempts": 1,
+                            "expire_at": null,
+                            "external_verification_redirect_url": null,
+                            "nonce": null,
+                            "error": null
+                          },
+                          "linked_to": [],
+                          "reserved": false,
+                          "created_at": 1714723200000,
+                          "updated_at": 1714723260000
+                        }
+                      ],
+                      "phone_numbers": [],
+                      "external_accounts": [],
+                      "enterprise_accounts": [],
+                      "passkeys": [],
+                      "password_enabled": true,
+                      "two_factor_enabled": false,
+                      "totp_enabled": false,
+                      "backup_code_enabled": false,
+                      "mfa_enabled_at": null,
+                      "mfa_disabled_at": null,
+                      "banned": false,
+                      "locked": false,
+                      "lockout_expires_at": null,
+                      "last_sign_in_at": 1714809600000,
+                      "last_active_at": 1714895999000,
+                      "delete_self_enabled": true,
+                      "locale": "en-US",
+                      "public_metadata": {
+                        "plan": "pro"
+                      },
+                      "private_metadata": {},
+                      "unsafe_metadata": {},
+                      "created_at": 1714723200000,
+                      "updated_at": 1714895999000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateUser",
+        "summary": "Update a user",
+        "description": "Partial update. Only the fields you send are touched; nullable\nfields can be cleared by sending `null`.\n",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdateRequest"
+              },
+              "examples": {
+                "rename": {
+                  "summary": "Rename + update public metadata",
+                  "value": {
+                    "first_name": "Janet",
+                    "public_metadata": {
+                      "plan": "enterprise"
+                    }
+                  }
+                },
+                "rotate_password": {
+                  "summary": "Force a password rotation and revoke other sessions",
+                  "value": {
+                    "password": "tr0ub4dor &3",
+                    "sign_out_of_other_sessions": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteUser",
+        "summary": "Delete a user",
+        "description": "Permanently delete the user, all their identifiers, sessions, and\nmetadata. Emits `user.deleted`.\n",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/ban": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "banUser",
+        "summary": "Ban a user",
+        "description": "Permanently block a user from authenticating. Existing sessions are\nrevoked. Idempotent: banning an already-banned user is a no-op.\n",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The banned user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/unban": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "unbanUser",
+        "summary": "Unban a user",
+        "description": "Lift a previous ban. Idempotent: unbanning a non-banned user is a no-op.\n",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The unbanned user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/lock": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "lockUser",
+        "summary": "Lock a user",
+        "description": "Temporarily prevent the user from authenticating. Honors the\nenvironment-level `max_lockout_duration` setting.\n",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The locked user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/unlock": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "unlockUser",
+        "summary": "Unlock a user",
+        "description": "Lift a temporary lockout. Idempotent.",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The unlocked user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/profile_image": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "uploadUserProfileImage",
+        "summary": "Upload a profile image",
+        "description": "Upload a new profile image for the user. Replaces the existing\nimage, if any. Maximum 10 MiB; allowed content types: `image/png`,\n`image/jpeg`, `image/webp`, `image/gif`.\n",
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Raw image bytes."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The user with the new `image_url` populated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "413": {
+            "description": "Image larger than the per-environment limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported image content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteUserProfileImage",
+        "summary": "Delete a profile image",
+        "description": "Remove the profile image and clear `image_url`. Idempotent.",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The user with `image_url = null`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/metadata": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "patch": {
+        "operationId": "updateUserMetadata",
+        "summary": "Patch user metadata",
+        "description": "Shallow-merge the supplied metadata buckets into the user. To clear\na key, send it with `null`. Top-level buckets you don't include are\nleft untouched.\n",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "public_metadata": {
+                    "$ref": "#/components/schemas/Metadata"
+                  },
+                  "private_metadata": {
+                    "$ref": "#/components/schemas/Metadata"
+                  },
+                  "unsafe_metadata": {
+                    "$ref": "#/components/schemas/Metadata"
+                  }
+                }
+              },
+              "examples": {
+                "set_plan": {
+                  "summary": "Promote the user to the enterprise plan",
+                  "value": {
+                    "public_metadata": {
+                      "plan": "enterprise"
+                    },
+                    "private_metadata": {
+                      "stripe_customer_id": "cus_XXXXX"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The user with merged metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/verify_password": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "verifyPassword",
+        "summary": "Verify a user's password",
+        "description": "Server-side password check. Returns `200 { verified: true }` on\nmatch, `200 { verified: false }` on mismatch. Subject to the\nstandard rate-limit bucket; repeated mismatches eventually return\n`429`.\n",
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "password"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "examples": {
+                "basic": {
+                  "value": {
+                    "password": "correct horse battery staple"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verification result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "verified"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "verified": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "examples": {
+                  "ok": {
+                    "value": {
+                      "verified": true
+                    }
+                  },
+                  "wrong": {
+                    "value": {
+                      "verified": false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/email_addresses": {
+      "post": {
+        "operationId": "createEmailAddress",
+        "summary": "Create an email address",
+        "description": "Attach a new email address to a user. By default the address is\ncreated unverified and a verification challenge is issued (email\ncode). Pass `verified: true` to skip the challenge — the BAPI is\nprivileged.\n",
+        "tags": [
+          "Email Addresses"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailAddressCreateRequest"
+              },
+              "examples": {
+                "self_serve": {
+                  "summary": "Add an unverified address (issues a code)",
+                  "value": {
+                    "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                    "email_address": "jane.alt@acme.com"
+                  }
+                },
+                "server_verified": {
+                  "summary": "Add an already-verified address and make it primary",
+                  "value": {
+                    "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                    "email_address": "jane@acme.com",
+                    "verified": true,
+                    "primary": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Email address created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailAddress"
+                },
+                "examples": {
+                  "unverified": {
+                    "value": {
+                      "id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                      "object": "email_address",
+                      "email_address": "jane.alt@acme.com",
+                      "verification": {
+                        "status": "unverified",
+                        "strategy": "email_code",
+                        "attempts": 0,
+                        "expire_at": 1714724000000,
+                        "external_verification_redirect_url": null,
+                        "nonce": null,
+                        "error": null
+                      },
+                      "linked_to": [],
+                      "reserved": false,
+                      "created_at": 1714723200000,
+                      "updated_at": 1714723200000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/email_addresses/{email_address_id}": {
+      "parameters": [
+        {
+          "name": "email_address_id",
+          "in": "path",
+          "required": true,
+          "description": "ID of the email address.",
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getEmailAddress",
+        "summary": "Get an email address",
+        "description": "Fetch a single `EmailAddress` by ID.",
+        "tags": [
+          "Email Addresses"
+        ],
+        "responses": {
+          "200": {
+            "description": "The email address.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailAddress"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateEmailAddress",
+        "summary": "Update an email address",
+        "description": "Mark the address verified server-side or promote it to the user's\nprimary address. Sending an empty body is a no-op.\n",
+        "tags": [
+          "Email Addresses"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailAddressUpdateRequest"
+              },
+              "examples": {
+                "promote": {
+                  "summary": "Mark verified and make primary",
+                  "value": {
+                    "verified": true,
+                    "primary": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated email address.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailAddress"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteEmailAddress",
+        "summary": "Delete an email address",
+        "description": "Permanently remove the address from the user. The owning user must\nhave at least one other identifier remaining; deleting the only\nidentifier returns `422`.\n",
+        "tags": [
+          "Email Addresses"
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/sessions": {
+      "get": {
+        "operationId": "listSessions",
+        "summary": "List sessions (BAPI)",
+        "description": "Paginated list of every session in the environment. The BAPI view\nis privileged and unscoped to a particular `Client` — use the\n`client_id`, `user_id`, and `status` filters to narrow.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          },
+          {
+            "$ref": "#/components/parameters/OrderByParam"
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "client_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "active",
+                "expired",
+                "ended",
+                "removed",
+                "replaced",
+                "revoked",
+                "abandoned"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of sessions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Session"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "for_user": {
+                    "summary": "Every active session for one user",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "sess_01HKX9SY9V7H7TF8C8K7J9X4ZC",
+                          "object": "session",
+                          "client_id": "clt_01HKX9SY9V7H7TF8C8K7J9X4ZA",
+                          "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                          "status": "active",
+                          "last_active_at": 1714895999000,
+                          "last_active_organization_id": null,
+                          "expire_at": 1717487999000,
+                          "abandon_at": 1717487999000,
+                          "actor": null,
+                          "latest_activity": {
+                            "id": "sa_01HKX9SY9V7H7TF8C8K7J9X4ZF",
+                            "object": "session_activity",
+                            "device_type": "desktop",
+                            "is_mobile": false,
+                            "browser_name": "Chrome",
+                            "browser_version": "124.0",
+                            "ip_address": "203.0.113.0",
+                            "city": "Berlin",
+                            "country": "DE"
+                          },
+                          "created_at": 1714723200000,
+                          "updated_at": 1714895999000
+                        }
+                      ],
+                      "total_count": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getSession",
+        "summary": "Get a session (BAPI)",
+        "description": "Fetch one `Session` by ID, irrespective of which `Client` it belongs to.",
+        "tags": [
+          "Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "The session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/revoke": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "revokeSession",
+        "summary": "Revoke a session (BAPI)",
+        "description": "Admin-side revocation. Marks the session `revoked` and immediately\ninvalidates its tokens. Idempotent.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "The revoked session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                },
+                "examples": {
+                  "revoked": {
+                    "value": {
+                      "id": "sess_01HKX9SY9V7H7TF8C8K7J9X4ZC",
+                      "object": "session",
+                      "client_id": "clt_01HKX9SY9V7H7TF8C8K7J9X4ZA",
+                      "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                      "status": "revoked",
+                      "last_active_at": 1714895999000,
+                      "last_active_organization_id": null,
+                      "expire_at": 1717487999000,
+                      "abandon_at": 1717487999000,
+                      "actor": null,
+                      "latest_activity": {
+                        "id": "sa_01HKX9SY9V7H7TF8C8K7J9X4ZF",
+                        "object": "session_activity",
+                        "device_type": "desktop",
+                        "is_mobile": false,
+                        "browser_name": "Chrome",
+                        "browser_version": "124.0",
+                        "ip_address": "203.0.113.0",
+                        "city": "Berlin",
+                        "country": "DE"
+                      },
+                      "created_at": 1714723200000,
+                      "updated_at": 1714896500000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/tokens": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "getSessionToken",
+        "summary": "Mint a session JWT (BAPI)",
+        "description": "Admin-side JWT mint. Same shape as the FAPI variant\n(`getClientSessionToken`) but BAPI-secured: useful for server-side\nrendering pipelines that need to forward a token to a downstream\nservice on behalf of a user.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "The minted token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "jwt"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "token"
+                    },
+                    "jwt": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "token": {
+                    "value": {
+                      "object": "token",
+                      "jwt": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImpfMTIifQ.eyJzdWIiOiJ1c2VyXzE…"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/tokens/{template_name}": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        },
+        {
+          "name": "template_name",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "getSessionTokenWithTemplate",
+        "summary": "Mint a session JWT with a custom template (BAPI, v0.7)",
+        "description": "Admin-side templated token mint. Always returns\n`404 jwt_template_not_found` in v0.1; the templating layer ships in\nv0.7 alongside the IdP role.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "The minted token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "jwt"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "token"
+                    },
+                    "jwt": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/environment": {
+      "get": {
+        "operationId": "getEnvironment",
+        "summary": "Get environment bootstrap config",
+        "description": "Public, unauthenticated. Returned at SDK boot to drive flow rendering,\nbranding, and locale selection. Cacheable for ~30 seconds.\n",
+        "tags": [
+          "Environment"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Environment configuration.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client": {
+      "get": {
+        "operationId": "getClient",
+        "summary": "Get the current client",
+        "description": "Returns the device-scoped `Client`. Lazily creates one and sets the\n`__client` cookie if the request didn't already carry one.\n",
+        "tags": [
+          "Client"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The current client.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Client"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "operationId": "createClient",
+        "summary": "Create / re-create the current client",
+        "description": "Force a fresh `Client` and `__client` cookie. Used by the SDK after\na sign-out-everywhere to obtain a clean device identity.\n",
+        "tags": [
+          "Client"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The freshly-issued client, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "destroyClient",
+        "summary": "Destroy the current client",
+        "description": "Revokes every session on this device and clears the `__client`\ncookie. The next request gets a fresh client via `GET /v1/client`.\n",
+        "tags": [
+          "Client"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Confirmation envelope (response is the destroyed client).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/client/handshake": {
+      "get": {
+        "operationId": "clientHandshake",
+        "summary": "Server-side handshake",
+        "description": "SSR handshake endpoint. The server-side renderer calls this with the\nincoming request's cookies; the response carries the\n`Set-Cookie: __client=…` header so the SSR proxy can set it on the\noutgoing HTML response.\n",
+        "tags": [
+          "Client"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "redirect_url",
+            "in": "query",
+            "description": "Caller URL the SDK should bounce back to after the handshake.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Handshake confirmation. Carries the `Set-Cookie: __client=…`\nheader.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "object",
+                    "redirect_url"
+                  ],
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "client_handshake"
+                    },
+                    "redirect_url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "uri"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins": {
+      "post": {
+        "operationId": "createSignIn",
+        "summary": "Create a sign-in attempt",
+        "description": "Start a sign-in flow. The caller may supply only the identifier (in\nwhich case the response carries `supported_first_factors` so the\nSDK can pick one), or supply an identifier + strategy (and password\nwhen applicable) to fold the first attempt into the create call.\n",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                    "description": "Email, phone (E.164), or username."
+                  },
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "password",
+                      "email_code",
+                      "reset_password_email_code",
+                      "ticket"
+                    ]
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "redirect_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Used by strategies that need a callback URL."
+                  },
+                  "ticket": {
+                    "type": "string",
+                    "description": "Single-use ticket from an invitation or magic link."
+                  },
+                  "transfer": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "captcha_token": {
+                    "type": "string"
+                  },
+                  "captcha_widget_type": {
+                    "type": "string",
+                    "enum": [
+                      "smart",
+                      "invisible",
+                      "managed"
+                    ]
+                  },
+                  "captcha_error": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "identify_only": {
+                  "summary": "Identify and let the SDK pick the next factor",
+                  "value": {
+                    "identifier": "jane@acme.com"
+                  }
+                },
+                "password_first_attempt": {
+                  "summary": "Identify + first-factor password in one call",
+                  "value": {
+                    "identifier": "jane@acme.com",
+                    "strategy": "password",
+                    "password": "correct horse battery staple"
+                  }
+                },
+                "email_code": {
+                  "summary": "Identify + start an email code",
+                  "value": {
+                    "identifier": "jane@acme.com",
+                    "strategy": "email_code"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "New (or transitioned) sign-in attempt, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins/{sign_in_id}": {
+      "parameters": [
+        {
+          "name": "sign_in_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getSignIn",
+        "summary": "Get a sign-in attempt",
+        "description": "Fetch the current state of an in-progress sign-in attempt by ID.",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The sign-in attempt.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignIn"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins/{sign_in_id}/prepare_first_factor": {
+      "parameters": [
+        {
+          "name": "sign_in_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "prepareFirstFactor",
+        "summary": "Prepare first-factor verification",
+        "description": "Issue a first-factor challenge (e.g. send the email code) without\nyet evaluating an answer. The next step is `attempt_first_factor`.\n",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "email_code",
+                      "reset_password_email_code"
+                    ]
+                  },
+                  "email_address_id": {
+                    "type": "string"
+                  },
+                  "phone_number_id": {
+                    "type": "string"
+                  },
+                  "redirect_url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "examples": {
+                "email_code": {
+                  "value": {
+                    "strategy": "email_code",
+                    "email_address_id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-in with the new `first_factor_verification`, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins/{sign_in_id}/attempt_first_factor": {
+      "parameters": [
+        {
+          "name": "sign_in_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "attemptFirstFactor",
+        "summary": "Attempt first-factor verification",
+        "description": "Submit the user's answer to the first-factor challenge. Strategies:\n\n- `password` — body `{strategy: \"password\", password: \"…\"}`.\n- `email_code` — body `{strategy: \"email_code\", code: \"123456\"}`.\n- `reset_password_email_code` — body\n  `{strategy: \"reset_password_email_code\", code: \"…\"}` — on success\n  the sign-in transitions to `needs_new_password`.\n- `ticket` — body `{strategy: \"ticket\", ticket: \"…\"}`.\n",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "password",
+                      "email_code",
+                      "reset_password_email_code",
+                      "ticket"
+                    ]
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "ticket": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Reserved for v0.5 (passkey)."
+                  }
+                }
+              },
+              "examples": {
+                "password": {
+                  "value": {
+                    "strategy": "password",
+                    "password": "correct horse battery staple"
+                  }
+                },
+                "email_code": {
+                  "value": {
+                    "strategy": "email_code",
+                    "code": "542178"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-in transitioned (possibly to `complete`), wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins/{sign_in_id}/prepare_second_factor": {
+      "parameters": [
+        {
+          "name": "sign_in_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "prepareSecondFactor",
+        "summary": "Prepare second-factor verification (v0.3+)",
+        "description": "Placeholder. v0.1 always returns `422 mfa_not_enabled`. The full\nsurface ships in v0.3.\n",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": true,
+                "properties": {
+                  "strategy": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-in with the new `second_factor_verification`, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins/{sign_in_id}/attempt_second_factor": {
+      "parameters": [
+        {
+          "name": "sign_in_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "attemptSecondFactor",
+        "summary": "Attempt second-factor verification (v0.3+)",
+        "description": "Placeholder. v0.1 always returns `422 mfa_not_enabled`. The full\nsurface ships in v0.3.\n",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": true,
+                "properties": {
+                  "strategy": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-in transitioned, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ins/{sign_in_id}/reset_password": {
+      "parameters": [
+        {
+          "name": "sign_in_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "resetPassword",
+        "summary": "Reset password during sign-in",
+        "description": "Called after `attemptFirstFactor` with `reset_password_email_code`\nsucceeded — i.e. the sign-in is in `needs_new_password`. Sets the\nnew password, then transitions the sign-in to `complete`. When\n`sign_out_of_other_sessions: true`, every other active session for\nthe user is revoked.\n",
+        "tags": [
+          "Sign-Ins"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "password"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "minLength": 8
+                  },
+                  "sign_out_of_other_sessions": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                }
+              },
+              "examples": {
+                "basic": {
+                  "value": {
+                    "password": "tr0ub4dor &3",
+                    "sign_out_of_other_sessions": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The completed sign-in, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ups": {
+      "post": {
+        "operationId": "createSignUp",
+        "summary": "Create a sign-up attempt",
+        "description": "Start a sign-up flow. Any subset of the supported fields may be\nsupplied; whatever's missing is reported in the response's\n`missing_fields[]`.\n",
+        "tags": [
+          "Sign-Ups"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "email_address": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone_number": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 8
+                  },
+                  "unsafe_metadata": {
+                    "$ref": "#/components/schemas/Metadata"
+                  },
+                  "redirect_url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "ticket": {
+                    "type": "string"
+                  },
+                  "transfer": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "legal_accepted": {
+                    "type": "boolean"
+                  },
+                  "captcha_token": {
+                    "type": "string"
+                  },
+                  "captcha_widget_type": {
+                    "type": "string",
+                    "enum": [
+                      "smart",
+                      "invisible",
+                      "managed"
+                    ]
+                  },
+                  "captcha_error": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "email_password": {
+                  "summary": "Email + password sign-up",
+                  "value": {
+                    "email_address": "jane@acme.com",
+                    "password": "correct horse battery staple",
+                    "first_name": "Jane",
+                    "last_name": "Doe"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The new sign-up attempt, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ups/{sign_up_id}": {
+      "parameters": [
+        {
+          "name": "sign_up_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getSignUp",
+        "summary": "Get a sign-up attempt",
+        "description": "Fetch the current state of an in-progress sign-up attempt by ID.",
+        "tags": [
+          "Sign-Ups"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The sign-up attempt.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignUp"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateSignUp",
+        "summary": "Patch missing sign-up fields",
+        "description": "Fill in fields that were missing in the create call. Sending the\nsame field twice transparently overwrites the previous value.\n",
+        "tags": [
+          "Sign-Ups"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "email_address": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone_number": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 8
+                  },
+                  "unsafe_metadata": {
+                    "$ref": "#/components/schemas/Metadata"
+                  },
+                  "legal_accepted": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The transitioned sign-up, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ups/{sign_up_id}/prepare_verification": {
+      "parameters": [
+        {
+          "name": "sign_up_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "prepareVerification",
+        "summary": "Prepare sign-up verification",
+        "description": "Issue a verification challenge for one of the unverified attributes\non the sign-up (e.g. send the email code). v0.1 supports\n`email_code`.\n",
+        "tags": [
+          "Sign-Ups"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "email_code"
+                    ]
+                  },
+                  "redirect_url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "examples": {
+                "email_code": {
+                  "value": {
+                    "strategy": "email_code"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-up with the new verification populated, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sign_ups/{sign_up_id}/attempt_verification": {
+      "parameters": [
+        {
+          "name": "sign_up_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "attemptVerification",
+        "summary": "Attempt sign-up verification",
+        "description": "Submit the user's answer to a sign-up challenge (the email code in\nv0.1). On success the matching attribute moves out of\n`unverified_fields` and — if no other requirements remain — the\nsign-up transitions to `complete` (sets `created_user_id` and\n`created_session_id`).\n",
+        "tags": [
+          "Sign-Ups"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "email_code"
+                    ]
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Reserved for v0.5 (passkey)."
+                  }
+                }
+              },
+              "examples": {
+                "email_code": {
+                  "value": {
+                    "strategy": "email_code",
+                    "code": "542178"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sign-up transitioned (possibly to `complete`), wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sessions/{session_id}": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getClientSession",
+        "summary": "Get a session",
+        "description": "Fetch a single `Session` by ID; returns the current status, expiry, and last activity.",
+        "tags": [
+          "Sessions"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                },
+                "examples": {
+                  "active": {
+                    "value": {
+                      "id": "sess_01HKX9SY9V7H7TF8C8K7J9X4ZC",
+                      "object": "session",
+                      "client_id": "clt_01HKX9SY9V7H7TF8C8K7J9X4ZA",
+                      "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                      "status": "active",
+                      "last_active_at": 1714895999000,
+                      "last_active_organization_id": null,
+                      "expire_at": 1717487999000,
+                      "abandon_at": 1717487999000,
+                      "actor": null,
+                      "latest_activity": {
+                        "id": "sa_01HKX9SY9V7H7TF8C8K7J9X4ZF",
+                        "object": "session_activity",
+                        "device_type": "desktop",
+                        "is_mobile": false,
+                        "browser_name": "Chrome",
+                        "browser_version": "124.0",
+                        "ip_address": "203.0.113.0",
+                        "city": "Berlin",
+                        "country": "DE"
+                      },
+                      "created_at": 1714723200000,
+                      "updated_at": 1714895999000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client/sessions/{session_id}/end": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "endClientSession",
+        "summary": "End a session (sign out on this device)",
+        "description": "Marks the session `ended` and invalidates its tokens. The session\nstays in `Client.sessions[]` for ~1 minute so the SDK can finish\nflushing analytics, then drops out.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ended session, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client/sessions/{session_id}/remove": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "removeClientSession",
+        "summary": "Remove a session immediately",
+        "description": "Like `end`, but drops the session from `Client.sessions[]` straight\naway. Used when the SDK wants to forget about it (e.g. user clicked\n\"Remove this device\" in the user profile).\n",
+        "tags": [
+          "Sessions"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The removed session, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client/sessions/{session_id}/touch": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "touchClientSession",
+        "summary": "Touch a session",
+        "description": "Update `last_active_at` and (optionally) the active organization.\nThe SDK calls this on every page view so the dashboard \"active\nsessions\" view is fresh.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "active_organization_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Switch the active organization. Always `null` in v0.1\nsince organizations land in v0.2.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The touched session, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/client/sessions/{session_id}/tokens": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "getClientSessionToken",
+        "summary": "Mint a session JWT",
+        "description": "Mint a short-lived RS256 JWT for the session. Use the templated\nsibling endpoint (`/tokens/{template_name}`) once JWT templates\nship in v0.7.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The minted token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "jwt"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "token"
+                    },
+                    "jwt": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "token": {
+                    "value": {
+                      "object": "token",
+                      "jwt": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImpfMTIifQ.eyJzdWIiOiJ1c2VyXzE…"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/client/sessions/{session_id}/tokens/{template_name}": {
+      "parameters": [
+        {
+          "name": "session_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        },
+        {
+          "name": "template_name",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$"
+          },
+          "description": "Name of the JWT template configured on the environment."
+        }
+      ],
+      "post": {
+        "operationId": "getClientSessionTokenWithTemplate",
+        "summary": "Mint a session JWT with a custom template (v0.7)",
+        "description": "Issue a JWT shaped by the named template. Always returns\n`404 jwt_template_not_found` in v0.1; the templating layer ships in\nv0.7 alongside the IdP role.\n",
+        "tags": [
+          "Sessions"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The minted token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "object",
+                    "jwt"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "const": "token"
+                    },
+                    "jwt": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/me": {
+      "get": {
+        "operationId": "getMe",
+        "summary": "Get the current user",
+        "description": "Return the authenticated user. Works on any active session; the SDK\nuses this to hydrate `useUser()` / `currentUser` in the framework\nbindings.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "me": {
+                    "summary": "A signed-in user",
+                    "value": {
+                      "id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+                      "object": "user",
+                      "external_id": null,
+                      "username": "jane",
+                      "first_name": "Jane",
+                      "last_name": "Doe",
+                      "image_url": null,
+                      "has_image": false,
+                      "primary_email_address_id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZE",
+                      "primary_phone_number_id": null,
+                      "email_addresses": [],
+                      "phone_numbers": [],
+                      "external_accounts": [],
+                      "enterprise_accounts": [],
+                      "passkeys": [],
+                      "password_enabled": true,
+                      "two_factor_enabled": false,
+                      "totp_enabled": false,
+                      "backup_code_enabled": false,
+                      "mfa_enabled_at": null,
+                      "mfa_disabled_at": null,
+                      "banned": false,
+                      "locked": false,
+                      "lockout_expires_at": null,
+                      "last_sign_in_at": 1714809600000,
+                      "last_active_at": 1714895999000,
+                      "delete_self_enabled": true,
+                      "locale": "en-US",
+                      "public_metadata": {
+                        "plan": "pro"
+                      },
+                      "private_metadata": {},
+                      "unsafe_metadata": {},
+                      "created_at": 1714723200000,
+                      "updated_at": 1714895999000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateMe",
+        "summary": "Update the current user",
+        "description": "Partial update over the FAPI-writable subset (display name fields,\n`unsafe_metadata`, `locale`). Privileged fields (`public_metadata`,\n`private_metadata`, `external_id`, password lifecycle) live on\nBAPI's `PATCH /v1/users/{id}`.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "username": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "first_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "last_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "unsafe_metadata": {
+                    "$ref": "#/components/schemas/Metadata"
+                  },
+                  "locale": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated user, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMe",
+        "summary": "Delete the current user (alias for delete_self)",
+        "description": "Convenience wrapper around `POST /v1/me/delete_self`. Subject to\nthe environment's `delete_self_enabled` setting.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The destroyed user, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/v1/me/profile_image": {
+      "post": {
+        "operationId": "uploadMyProfileImage",
+        "summary": "Upload my profile image",
+        "description": "Upload a new profile image. Replaces the existing image, if any.\nMaximum 10 MiB; allowed content types: `image/png`, `image/jpeg`,\n`image/webp`, `image/gif`.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The user with the new `image_url`, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "413": {
+            "description": "Image too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported image type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMyProfileImage",
+        "summary": "Delete my profile image",
+        "description": "Remove the profile image and clear `image_url`. Idempotent.",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The user with `image_url = null`, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/me/email_addresses": {
+      "get": {
+        "operationId": "listMyEmailAddresses",
+        "summary": "List my email addresses",
+        "description": "Every email address attached to the current user, with verification state.",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "My email addresses.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailAddress"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createMyEmailAddress",
+        "summary": "Add an email address to my account",
+        "description": "Attach a new email to the current user. Always created unverified;\nfollow up with `prepare_verification` + `attempt_verification`.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "email_address"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "email_address": {
+                    "type": "string",
+                    "format": "email",
+                    "maxLength": 254
+                  }
+                }
+              },
+              "examples": {
+                "add": {
+                  "value": {
+                    "email_address": "jane.alt@acme.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The new email address, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/me/email_addresses/{email_address_id}": {
+      "parameters": [
+        {
+          "name": "email_address_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getMyEmailAddress",
+        "summary": "Get one of my email addresses",
+        "description": "Fetch a single email address attached to the current user, by ID.",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The email address.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailAddress"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateMyEmailAddress",
+        "summary": "Promote one of my email addresses to primary",
+        "description": "Only verified addresses can be made primary.",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "primary": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated address, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMyEmailAddress",
+        "summary": "Remove one of my email addresses",
+        "description": "Detach the address from the current user. The user must have at\nleast one other identifier remaining; deleting the last one returns\n`422`.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The deleted address, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/me/email_addresses/{email_address_id}/prepare_verification": {
+      "parameters": [
+        {
+          "name": "email_address_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "prepareMyEmailVerification",
+        "summary": "Prepare email verification",
+        "description": "Issue a fresh email-code challenge for one of my unverified addresses.",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategy"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "email_code"
+                    ]
+                  }
+                }
+              },
+              "examples": {
+                "basic": {
+                  "value": {
+                    "strategy": "email_code"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The address with the new verification, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/me/email_addresses/{email_address_id}/attempt_verification": {
+      "parameters": [
+        {
+          "name": "email_address_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "attemptMyEmailVerification",
+        "summary": "Attempt email verification",
+        "description": "Submit the code received in email; flips the address to `verified` on match.",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "minLength": 4,
+                    "maxLength": 12
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The (now-verified) address, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/me/sessions": {
+      "get": {
+        "operationId": "listMySessions",
+        "summary": "List my active sessions",
+        "description": "All non-ended sessions for the current user across every device.\nPowers the \"active sessions\" panel in the user profile.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "My sessions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Session"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/me/change_password": {
+      "post": {
+        "operationId": "changeMyPassword",
+        "summary": "Change my password",
+        "description": "Replace the user's password. Always requires the current password\nwhen one is set; the `new_password` is validated against the\nenvironment's strength policy.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "new_password"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "current_password": {
+                    "type": "string",
+                    "description": "Required if the user already has a password."
+                  },
+                  "new_password": {
+                    "type": "string",
+                    "minLength": 8
+                  },
+                  "sign_out_of_other_sessions": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The user with `password_enabled = true`, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/me/password": {
+      "delete": {
+        "operationId": "removeMyPassword",
+        "summary": "Remove my password",
+        "description": "Clear the user's password digest, leaving them with whatever other\nfactors are configured (e.g. magic link). Returns `422` when the\nenvironment requires a password.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "current_password"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "current_password": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The user with `password_enabled = false`, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/me/delete_self": {
+      "post": {
+        "operationId": "deleteMyself",
+        "summary": "Delete my account",
+        "description": "Permanently destroy the current user (and every session, identifier,\nand metadata). Requires the environment's `delete_self_enabled`\nsetting to be `true`.\n",
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "client_cookie": []
+          },
+          {
+            "dev_browser_jwt": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The destroyed user, wrapped.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponseEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/v1/invitations": {
+      "get": {
+        "operationId": "listInvitations",
+        "summary": "List invitations",
+        "description": "Paginated list of invitations, filterable by `status` and free-text `query`.",
+        "tags": [
+          "Invitations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          },
+          {
+            "$ref": "#/components/parameters/OrderByParam"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "accepted",
+                "revoked",
+                "expired"
+              ]
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Free-text match against `email_address`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of invitations.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Invitation"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createInvitation",
+        "summary": "Create an invitation",
+        "description": "Mint a single invitation. By default an email is sent immediately;\nset `notify: false` to mint a ticket without sending.\n",
+        "tags": [
+          "Invitations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvitationCreateRequest"
+              },
+              "examples": {
+                "basic": {
+                  "summary": "Email + redirect_url, default expiry",
+                  "value": {
+                    "email_address": "jane@acme.com",
+                    "redirect_url": "https://app.acme.com/welcome",
+                    "public_metadata": {
+                      "plan": "pro"
+                    }
+                  }
+                },
+                "silent": {
+                  "summary": "Mint ticket only, no email",
+                  "value": {
+                    "email_address": "jane@acme.com",
+                    "notify": false,
+                    "expires_in_days": 30
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The new invitation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invitation"
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "id": "inv_01HKX9SY9V7H7TF8C8K7J9X4ZG",
+                      "object": "invitation",
+                      "email_address": "jane@acme.com",
+                      "redirect_url": "https://app.acme.com/welcome",
+                      "public_metadata": {
+                        "plan": "pro"
+                      },
+                      "status": "pending",
+                      "revoked": false,
+                      "url": "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up&redirect_url=https%3A%2F%2Fapp.acme.com%2Fwelcome",
+                      "expires_at": 1717487999000,
+                      "created_at": 1714895999000,
+                      "updated_at": 1714895999000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/invitations/bulk": {
+      "post": {
+        "operationId": "bulkCreateInvitations",
+        "summary": "Bulk-create invitations",
+        "description": "Atomic batch create. If any invitation fails validation the entire\nrequest is rejected; the response describes the offending row(s).\n",
+        "tags": [
+          "Invitations"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvitationBulkCreateRequest"
+              },
+              "examples": {
+                "batch": {
+                  "summary": "Two invitations in one call",
+                  "value": {
+                    "invitations": [
+                      {
+                        "email_address": "jane@acme.com",
+                        "redirect_url": "https://app.acme.com/welcome"
+                      },
+                      {
+                        "email_address": "john@acme.com",
+                        "notify": false,
+                        "expires_in_days": 30
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created invitations.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "total_count"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Invitation"
+                      }
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/invitations/{invitation_id}/revoke": {
+      "parameters": [
+        {
+          "name": "invitation_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "revokeInvitation",
+        "summary": "Revoke an invitation",
+        "description": "Mark the invitation `revoked` and invalidate its ticket. Idempotent:\nrevoking an already-revoked invitation is a no-op.\n",
+        "tags": [
+          "Invitations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The revoked invitation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invitation"
+                },
+                "examples": {
+                  "revoked": {
+                    "value": {
+                      "id": "inv_01HKX9SY9V7H7TF8C8K7J9X4ZG",
+                      "object": "invitation",
+                      "email_address": "jane@acme.com",
+                      "redirect_url": null,
+                      "public_metadata": {},
+                      "status": "revoked",
+                      "revoked": true,
+                      "url": "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up",
+                      "expires_at": 1717487999000,
+                      "created_at": 1714895999000,
+                      "updated_at": 1714896200000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/allowlist_identifiers": {
+      "get": {
+        "operationId": "listAllowlistIdentifiers",
+        "summary": "List allowlist identifiers",
+        "description": "Paginated list. The allowlist gates sign-ups while the environment is in `restricted` mode.",
+        "tags": [
+          "Allowlist Identifiers"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of allowlist identifiers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AllowlistIdentifier"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createAllowlistIdentifier",
+        "summary": "Create an allowlist identifier",
+        "description": "Add a literal identifier or a wildcard pattern (`*@example.com`).",
+        "tags": [
+          "Allowlist Identifiers"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "identifier"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "notify": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              },
+              "examples": {
+                "literal": {
+                  "summary": "Literal email address",
+                  "value": {
+                    "identifier": "jane@acme.com",
+                    "notify": true
+                  }
+                },
+                "wildcard": {
+                  "summary": "Anyone at the acme.com domain",
+                  "value": {
+                    "identifier": "*@acme.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllowlistIdentifier"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/allowlist_identifiers/{identifier_id}": {
+      "parameters": [
+        {
+          "name": "identifier_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "deleteAllowlistIdentifier",
+        "summary": "Delete an allowlist identifier",
+        "description": "Idempotent removal of a single allowlist row.",
+        "tags": [
+          "Allowlist Identifiers"
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/blocklist_identifiers": {
+      "get": {
+        "operationId": "listBlocklistIdentifiers",
+        "summary": "List blocklist identifiers",
+        "description": "Paginated list. Blocklist matches always refuse sign-up, even in `public` mode.",
+        "tags": [
+          "Blocklist Identifiers"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of blocklist identifiers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/BlocklistIdentifier"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createBlocklistIdentifier",
+        "summary": "Create a blocklist identifier",
+        "description": "Add a literal identifier or a wildcard pattern.",
+        "tags": [
+          "Blocklist Identifiers"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "identifier"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "literal": {
+                  "value": {
+                    "identifier": "spammer@acme.com"
+                  }
+                },
+                "wildcard": {
+                  "value": {
+                    "identifier": "*@disposable-mailbox.test"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created identifier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlocklistIdentifier"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/blocklist_identifiers/{identifier_id}": {
+      "parameters": [
+        {
+          "name": "identifier_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "deleteBlocklistIdentifier",
+        "summary": "Delete a blocklist identifier",
+        "description": "Idempotent removal of a single blocklist row.",
+        "tags": [
+          "Blocklist Identifiers"
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/redirect_urls": {
+      "get": {
+        "operationId": "listRedirectUrls",
+        "summary": "List redirect URLs",
+        "description": "Paginated list of allowed post-flow redirect targets.",
+        "tags": [
+          "Redirect URLs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of redirect URLs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/RedirectUrl"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createRedirectUrl",
+        "summary": "Create a redirect URL",
+        "description": "Add a URL to the allowlist. HTTPS required in production\nenvironments; `http://localhost:*` is allowed in test environments.\n",
+        "tags": [
+          "Redirect URLs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "examples": {
+                "prod": {
+                  "value": {
+                    "url": "https://app.acme.com/welcome"
+                  }
+                },
+                "dev": {
+                  "value": {
+                    "url": "http://localhost:3000/sign-in"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created redirect URL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedirectUrl"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/redirect_urls/{redirect_url_id}": {
+      "parameters": [
+        {
+          "name": "redirect_url_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getRedirectUrl",
+        "summary": "Get a redirect URL",
+        "description": "Fetch a single redirect URL by ID.",
+        "tags": [
+          "Redirect URLs"
+        ],
+        "responses": {
+          "200": {
+            "description": "The redirect URL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedirectUrl"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteRedirectUrl",
+        "summary": "Delete a redirect URL",
+        "description": "Idempotent removal.",
+        "tags": [
+          "Redirect URLs"
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/instance": {
+      "get": {
+        "operationId": "getInstance",
+        "summary": "Get instance settings",
+        "description": "Returns the composite per-environment settings tree. Secret\ncredentials (`attack_protection.captcha.secret_key`,\n`attack_protection.brute_force.secret`) and any `private_metadata`\nare write-only and never appear here.\n",
+        "tags": [
+          "Instance"
+        ],
+        "responses": {
+          "200": {
+            "description": "Instance settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSettings"
+                },
+                "examples": {
+                  "production": {
+                    "summary": "A typical production environment",
+                    "value": {
+                      "object": "instance_settings",
+                      "support_email": "support@acme.com",
+                      "enhanced_email_deliverability": false,
+                      "sign_up_modes": [
+                        "public"
+                      ],
+                      "attribute_settings": {
+                        "email_address": {
+                          "enabled": true,
+                          "required": true,
+                          "used_for_first_factor": true,
+                          "used_for_second_factor": false,
+                          "verifications": [
+                            "email_code"
+                          ],
+                          "verify_at_sign_up": true
+                        },
+                        "password": {
+                          "enabled": true,
+                          "required": true,
+                          "used_for_first_factor": true,
+                          "used_for_second_factor": false,
+                          "verifications": [],
+                          "verify_at_sign_up": false
+                        }
+                      },
+                      "restrictions": {
+                        "allowlist_enabled": false,
+                        "blocklist_enabled": false,
+                        "block_email_subaddresses": false,
+                        "block_disposable_email_domains": true,
+                        "ignore_dots_for_gmail_addresses": true
+                      },
+                      "attack_protection": {
+                        "captcha": {
+                          "provider": "turnstile",
+                          "widget_type": "smart",
+                          "public_key": "0x4AAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        "brute_force": {
+                          "enabled": true,
+                          "max_attempts": 100,
+                          "lockout_duration_seconds": 3600
+                        },
+                        "device_tracking": {
+                          "enabled": false,
+                          "require_device_trust": false
+                        }
+                      },
+                      "sessions": {
+                        "lifetime_seconds": 604800,
+                        "inactivity_timeout_seconds": null,
+                        "multi_session": true,
+                        "max_concurrent_sessions_per_client": 10,
+                        "url_based_session_syncing": false,
+                        "session_token_template": null
+                      },
+                      "paths": {
+                        "sign_in_url": "https://app.acme.com/sign-in",
+                        "sign_up_url": "https://app.acme.com/sign-up",
+                        "after_sign_in_url": "https://app.acme.com/dashboard",
+                        "after_sign_up_url": "https://app.acme.com/welcome",
+                        "unauthorized_sign_in_url": "https://app.acme.com/forbidden",
+                        "user_profile_url": "https://app.acme.com/profile",
+                        "create_organization_url": null,
+                        "organization_profile_url": null,
+                        "after_leave_organization_url": null,
+                        "after_create_organization_url": null,
+                        "home_url": "https://app.acme.com"
+                      },
+                      "test_mode": "rejected",
+                      "signing_keys": {
+                        "rotation_cadence_days": 90,
+                        "pre_publish_window_seconds": 86400,
+                        "retire_window_seconds": 604800
+                      },
+                      "organizations": {
+                        "enabled": false
+                      },
+                      "audit_log_retention_days": 365
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateInstance",
+        "summary": "Patch instance settings",
+        "description": "Update top-level toggles and the writable nested groups. Secret\ncredentials supplied here are stored but never returned by `GET`.\n",
+        "tags": [
+          "Instance"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated instance settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/instance/restrictions": {
+      "patch": {
+        "operationId": "updateRestrictions",
+        "summary": "Patch sign-up restrictions",
+        "description": "Convenience endpoint that scopes the patch to the\n`restrictions` group. Equivalent to `PATCH /v1/instance` with\n`{ \"restrictions\": { … } }` but doesn't require sending the rest of\nthe settings tree.\n",
+        "tags": [
+          "Instance"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestrictionsUpdateRequest"
+              },
+              "examples": {
+                "turn_on_allowlist": {
+                  "summary": "Switch to allowlist mode and refuse disposable email domains",
+                  "value": {
+                    "allowlist_enabled": true,
+                    "block_disposable_email_domains": true,
+                    "block_email_subaddresses": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated instance settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/instance/organization_settings": {
+      "patch": {
+        "operationId": "updateOrganizationSettings",
+        "summary": "Patch organization settings (v0.2 placeholder)",
+        "description": "v0.1 only accepts `enabled: false`. The full schema lands in v0.2\nalong with the organization API surface.\n",
+        "tags": [
+          "Instance"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationSettingsUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated instance settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/webhooks/endpoints": {
+      "get": {
+        "operationId": "listWebhookEndpoints",
+        "summary": "List webhook endpoints",
+        "description": "Paginated list of every endpoint configured on the environment.",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of endpoints. `signing_secret` is omitted on every row.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/WebhookEndpoint"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "page": {
+                    "summary": "Two endpoints — neither carries `signing_secret`.",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZH",
+                          "object": "webhook_endpoint",
+                          "url": "https://app.acme.com/webhooks/authn",
+                          "signing_secret_prefix": "whsec_dG",
+                          "enabled_event_types": [
+                            "user.created",
+                            "user.deleted"
+                          ],
+                          "enabled": true,
+                          "created_at": 1714895999000,
+                          "updated_at": 1714895999000
+                        },
+                        {
+                          "id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZJ",
+                          "object": "webhook_endpoint",
+                          "url": "https://app.acme.com/webhooks/sessions",
+                          "signing_secret_prefix": "whsec_xY",
+                          "enabled_event_types": [
+                            "session.created",
+                            "session.revoked"
+                          ],
+                          "enabled": false,
+                          "created_at": 1714809600000,
+                          "updated_at": 1714895500000
+                        }
+                      ],
+                      "total_count": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createWebhookEndpoint",
+        "summary": "Create a webhook endpoint",
+        "description": "Mint a new endpoint **and** its `signing_secret`. The secret is\nreturned exactly once in this response — copy it into the customer\nside immediately. Subsequent `GET` calls won't include it.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookEndpointCreateRequest"
+              },
+              "examples": {
+                "subscribe_users": {
+                  "summary": "Subscribe to every user.* event",
+                  "value": {
+                    "url": "https://app.acme.com/webhooks/authn",
+                    "enabled_event_types": [
+                      "user.created",
+                      "user.updated",
+                      "user.deleted"
+                    ]
+                  }
+                },
+                "everything": {
+                  "summary": "Catch-all",
+                  "value": {
+                    "url": "https://app.acme.com/webhooks/authn",
+                    "enabled_event_types": [
+                      "*"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The new endpoint, with the one-time `signing_secret`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZH",
+                      "object": "webhook_endpoint",
+                      "url": "https://app.acme.com/webhooks/authn",
+                      "signing_secret": "whsec_dGVzdC1zZWNyZXQtZG8tbm90LXJldXNlLXRoaXM=",
+                      "signing_secret_prefix": "whsec_dG",
+                      "enabled_event_types": [
+                        "user.created",
+                        "user.updated",
+                        "user.deleted"
+                      ],
+                      "enabled": true,
+                      "created_at": 1714895999000,
+                      "updated_at": 1714895999000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/v1/webhooks/endpoints/{endpoint_id}": {
+      "parameters": [
+        {
+          "name": "endpoint_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getWebhookEndpoint",
+        "summary": "Get a webhook endpoint",
+        "description": "Fetch a single endpoint. `signing_secret` is **never** included in\nthis response — only the read-safe `signing_secret_prefix`.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "The endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                },
+                "examples": {
+                  "endpoint": {
+                    "summary": "Note the absence of `signing_secret`.",
+                    "value": {
+                      "id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZH",
+                      "object": "webhook_endpoint",
+                      "url": "https://app.acme.com/webhooks/authn",
+                      "signing_secret_prefix": "whsec_dG",
+                      "enabled_event_types": [
+                        "user.created",
+                        "user.updated"
+                      ],
+                      "enabled": true,
+                      "created_at": 1714895999000,
+                      "updated_at": 1714895999000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateWebhookEndpoint",
+        "summary": "Update a webhook endpoint",
+        "description": "Patch any of `url` / `enabled_event_types` / `enabled`. The\n`signing_secret` cannot be set this way — use `rotate_secret`.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookEndpointUpdateRequest"
+              },
+              "examples": {
+                "add_events": {
+                  "summary": "Subscribe to invitations as well",
+                  "value": {
+                    "enabled_event_types": [
+                      "user.created",
+                      "user.updated",
+                      "user.deleted",
+                      "invitation.created"
+                    ]
+                  }
+                },
+                "disable": {
+                  "summary": "Pause an endpoint without deleting it",
+                  "value": {
+                    "enabled": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated endpoint (still no `signing_secret`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteWebhookEndpoint",
+        "summary": "Delete a webhook endpoint",
+        "description": "Permanently remove the endpoint. In-flight retries are abandoned;\nthe historical `WebhookDelivery` rows stay for audit but are\nflagged with `endpoint_id` of the now-deleted endpoint.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/webhooks/endpoints/{endpoint_id}/rotate_secret": {
+      "parameters": [
+        {
+          "name": "endpoint_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "rotateWebhookEndpointSecret",
+        "summary": "Rotate a webhook endpoint's signing secret",
+        "description": "Mint a fresh `signing_secret` and return it once. The previous\nsecret stays live for an overlap window (5 minutes by default) so\nin-flight deliveries continue to verify; after that, the new\nsecret is the only valid one.\n\nThe dispatcher signs each delivery during the overlap with a\nmulti-value `svix-signature` header (`v1,<old> v1,<new>`) so\ncustomer verifiers that already accept multiple `v1,…` entries\nwon't see any failed deliveries.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "overlap_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 86400,
+                    "default": 300,
+                    "description": "How long both secrets stay valid. `0` cuts over instantly\n(use only when you trust the customer endpoint to update\nsynchronously).\n"
+                  }
+                }
+              },
+              "examples": {
+                "longer_overlap": {
+                  "summary": "One-hour overlap during a coordinated rollout",
+                  "value": {
+                    "overlap_seconds": 3600
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The endpoint with the new one-time `signing_secret`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                },
+                "examples": {
+                  "rotated": {
+                    "value": {
+                      "id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZH",
+                      "object": "webhook_endpoint",
+                      "url": "https://app.acme.com/webhooks/authn",
+                      "signing_secret": "whsec_bmV3LXNlY3JldC1jb3B5LWl0LW5vdyE=",
+                      "signing_secret_prefix": "whsec_bm",
+                      "enabled_event_types": [
+                        "user.created",
+                        "user.updated",
+                        "user.deleted"
+                      ],
+                      "enabled": true,
+                      "created_at": 1714895999000,
+                      "updated_at": 1714896500000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/webhooks/deliveries": {
+      "get": {
+        "operationId": "listWebhookDeliveries",
+        "summary": "List webhook deliveries",
+        "description": "Paginated audit log of delivery attempts. Combine the filters below\nto investigate why a particular endpoint is misbehaving.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetParam"
+          },
+          {
+            "name": "endpoint_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "event_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "event_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "succeeded",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "created_at_after",
+            "in": "query",
+            "required": false,
+            "description": "Unix ms; only return deliveries created strictly after this instant.",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "created_at_before",
+            "in": "query",
+            "required": false,
+            "description": "Unix ms; only return deliveries created strictly before this instant.",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of deliveries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PaginatedList"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/WebhookDelivery"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "examples": {
+                  "failures": {
+                    "summary": "Failed deliveries to one endpoint in the last hour",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "whd_01HKX9SY9V7H7TF8C8K7J9X4ZK",
+                          "object": "webhook_delivery",
+                          "endpoint_id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZH",
+                          "event_id": "evt_01HKX9SY9V7H7TF8C8K7J9X4ZM",
+                          "event_type": "user.created",
+                          "attempt": 3,
+                          "response_status": 500,
+                          "response_body": "{\"error\":\"internal\"}",
+                          "next_retry_at": 1714896800000,
+                          "succeeded": false,
+                          "created_at": 1714896500000
+                        }
+                      ],
+                      "total_count": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/webhooks/deliveries/{delivery_id}": {
+      "parameters": [
+        {
+          "name": "delivery_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getWebhookDelivery",
+        "summary": "Get a webhook delivery",
+        "description": "Fetch one delivery attempt by ID.",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "The delivery.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDelivery"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/webhooks/deliveries/{delivery_id}/replay": {
+      "parameters": [
+        {
+          "name": "delivery_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "replayWebhookDelivery",
+        "summary": "Replay a webhook delivery",
+        "description": "Re-send the original event payload to the original endpoint. The\nreplay is a fresh attempt with a new `WebhookDelivery.id` and\n`attempt = 1`; it shares the same `event_id` as the original so\ncustomers can correlate.\n\nCommon use: a customer endpoint went down for a few hours, missed\na batch of `user.created` events, and the operator wants to backfill\nafter the endpoint comes back.\n",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKeyHeader"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The replay attempt.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDelivery"
+                },
+                "examples": {
+                  "replayed": {
+                    "value": {
+                      "id": "whd_01HKX9SY9V7H7TF8C8K7J9X4ZN",
+                      "object": "webhook_delivery",
+                      "endpoint_id": "whe_01HKX9SY9V7H7TF8C8K7J9X4ZH",
+                      "event_id": "evt_01HKX9SY9V7H7TF8C8K7J9X4ZM",
+                      "event_type": "user.created",
+                      "attempt": 1,
+                      "response_status": null,
+                      "response_body": null,
+                      "next_retry_at": null,
+                      "succeeded": false,
+                      "created_at": 1714900000000
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
   "components": {
     "securitySchemes": {
       "bearer_secret_key": {
@@ -233,6 +5978,2364 @@
             "examples": [
               "req_01HKX9SY9V7H7TF8C8K7J9X4ZD"
             ]
+          }
+        }
+      },
+      "Verification": {
+        "type": "object",
+        "description": "The state of a verification challenge attached to an identifier\n(`EmailAddress`, eventually `PhoneNumber`, …) or an in-progress\n`SignInAttempt` / `SignUpAttempt` factor.\n\n`status` is the consumer-visible lifecycle. `strategy` records\n*how* the challenge is being completed; the set of allowed strategies\ngrows with each milestone.\n",
+        "required": [
+          "status",
+          "strategy",
+          "attempts"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "unverified",
+              "verified",
+              "transferable",
+              "failed",
+              "expired"
+            ],
+            "description": "- `unverified` — challenge created, no successful attempt yet.\n- `verified` — challenge succeeded; the parent identifier is now trusted.\n- `transferable` — succeeded against an OAuth provider but the local\n  account doesn't exist yet (used during sign-up).\n- `failed` — too many wrong attempts; the challenge can no longer be retried.\n- `expired` — `expire_at` is in the past; the challenge must be re-issued.\n"
+          },
+          "strategy": {
+            "type": "string",
+            "description": "How this verification is being completed. v0.1 issues `email_code`,\n`reset_password_email_code`, `ticket`, `password`, and `transfer`;\nOAuth, phone, passkeys, and TOTP land in later milestones.\n",
+            "examples": [
+              "email_code",
+              "reset_password_email_code",
+              "password",
+              "ticket",
+              "transfer",
+              "oauth_google",
+              "phone_code",
+              "passkey",
+              "totp",
+              "backup_code"
+            ]
+          },
+          "attempts": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of confirm attempts made against this challenge."
+          },
+          "expire_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "Unix ms after which the challenge can no longer be confirmed. `null`\nfor strategies that don't expire (e.g. a `password` factor).\n"
+          },
+          "external_verification_redirect_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "For redirect-based strategies (OAuth, magic-link), the URL the\nbrowser should hand off to. `null` otherwise.\n"
+          },
+          "nonce": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Strategy-specific opaque blob. For OAuth this is the state nonce;\nfor passkey it's the authenticator challenge.\n"
+          },
+          "error": {
+            "description": "Last error returned by the strategy, if any.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Error"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "EmailAddress": {
+        "type": "object",
+        "description": "An email identifier owned by a `User`. A user may have many email\naddresses; exactly one is the primary (referenced by\n`User.primary_email_address_id`). A new address starts unverified\nand becomes a usable sign-in identifier once `verification.status`\nreaches `verified`.\n",
+        "required": [
+          "id",
+          "object",
+          "email_address",
+          "verification",
+          "linked_to",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "email_address"
+          },
+          "email_address": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 254,
+            "description": "The address itself, lower-cased and trimmed by the server."
+          },
+          "verification": {
+            "description": "Current verification challenge for this address, or `null` if the\naddress was created server-side already verified (e.g. via BAPI\nwith `verified: true`).\n",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Verification"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "linked_to": {
+            "type": "array",
+            "description": "External / enterprise account links that surfaced this address.\nEmpty in v0.1; populated as connections land.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/Id"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Account type (e.g. `oauth_google`, `enterprise_account`)."
+                }
+              }
+            }
+          },
+          "reserved": {
+            "type": "boolean",
+            "default": false,
+            "description": "`true` when the address is held by an `AllowlistIdentifier` /\n`Invitation` and is not yet attached to a user account.\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "description": "An end-user identity within an `Environment`. Carries the canonical\nidentifier set (email addresses, phone numbers, external accounts,\npasskeys), the auth-state flags (password, MFA), the moderation state\n(banned, locked), the lifecycle timestamps, and the three flavours of\nmetadata.\n\nPhone numbers, external accounts, enterprise accounts, and passkeys\nare present in the shape today (as empty arrays in v0.1) so SDKs can\ngenerate stable types up front; the corresponding endpoints land in\nlater milestones (v0.4 / v0.5 / v0.6).\n",
+        "required": [
+          "id",
+          "object",
+          "email_addresses",
+          "phone_numbers",
+          "external_accounts",
+          "enterprise_accounts",
+          "passkeys",
+          "has_image",
+          "password_enabled",
+          "two_factor_enabled",
+          "totp_enabled",
+          "backup_code_enabled",
+          "banned",
+          "locked",
+          "delete_self_enabled",
+          "public_metadata",
+          "private_metadata",
+          "unsafe_metadata",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "user"
+          },
+          "external_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 255,
+            "description": "Caller-supplied stable identifier. Indexed and unique within the\nenvironment. Useful for migrating users from another system.\n"
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 4,
+            "maxLength": 64
+          },
+          "first_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "last_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "image_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "Cached CDN URL for the user's profile image. `null` when\n`has_image` is `false`.\n"
+          },
+          "has_image": {
+            "type": "boolean",
+            "description": "Convenience flag derived from `image_url`. SDKs hide UI affordances\nthat depend on a real avatar based on this field.\n"
+          },
+          "primary_email_address_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pointer into `email_addresses[]`. `null` for users created with no\nverified email (e.g. username-only).\n"
+          },
+          "primary_phone_number_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pointer into `phone_numbers[]`. v0.1 always returns `null` (phone\nidentifiers ship in v0.4).\n"
+          },
+          "email_addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EmailAddress"
+            }
+          },
+          "phone_numbers": {
+            "type": "array",
+            "description": "Reserved for v0.4. Always returned as `[]` in v0.1.\n",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "external_accounts": {
+            "type": "array",
+            "description": "Reserved for v0.4 (OAuth connections). Always `[]` in v0.1.\n",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "enterprise_accounts": {
+            "type": "array",
+            "description": "Reserved for v0.6 (enterprise SSO). Always `[]` in v0.1.\n",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "passkeys": {
+            "type": "array",
+            "description": "Reserved for v0.5 (WebAuthn). Always `[]` in v0.1.\n",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "password_enabled": {
+            "type": "boolean",
+            "description": "`true` when the user has a stored password digest. Resetting via\n\"forgot password\" flips this to `true` after the new password is set.\n"
+          },
+          "two_factor_enabled": {
+            "type": "boolean",
+            "description": "`true` when at least one second factor is active. Always `false` in\nv0.1 (MFA ships in v0.3).\n"
+          },
+          "totp_enabled": {
+            "type": "boolean",
+            "description": "Always `false` in v0.1 (TOTP ships in v0.3)."
+          },
+          "backup_code_enabled": {
+            "type": "boolean",
+            "description": "Always `false` in v0.1 (backup codes ship in v0.3)."
+          },
+          "mfa_enabled_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "When MFA was first enabled. `null` until v0.3."
+          },
+          "mfa_disabled_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "When MFA was last disabled. `null` until v0.3."
+          },
+          "banned": {
+            "type": "boolean",
+            "description": "`true` when the user is permanently blocked from authenticating.\nToggle via `POST /v1/users/{id}/ban` and `/unban`.\n"
+          },
+          "locked": {
+            "type": "boolean",
+            "description": "`true` when the user is temporarily locked out (e.g. brute-force\nprotection). Toggle via `POST /v1/users/{id}/lock` and `/unlock`.\n"
+          },
+          "lockout_expires_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "Unix ms after which a `locked` user is automatically unlocked.\n`null` when not locked or the lock is indefinite.\n"
+          },
+          "last_sign_in_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "last_active_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "delete_self_enabled": {
+            "type": "boolean",
+            "description": "Mirrors the environment-level setting at the time of read; tells\nthe FAPI whether the user can call `DELETE /v1/me`.\n"
+          },
+          "locale": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "BCP-47 tag (e.g. `en-US`). Used to localize emails sent to the user."
+          },
+          "public_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "private_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "unsafe_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "UserCreateRequest": {
+        "type": "object",
+        "description": "Body for `POST /v1/users`. All fields are optional, but the resulting\nuser must be addressable: at least one of `email_address`,\n`phone_number`, `username`, or `external_id` is required by the\nserver.\n",
+        "additionalProperties": false,
+        "properties": {
+          "external_id": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Caller-supplied stable identifier. Must be unique in the environment."
+          },
+          "username": {
+            "type": "string",
+            "minLength": 4,
+            "maxLength": 64
+          },
+          "first_name": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "last_name": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "email_address": {
+            "type": "array",
+            "description": "Initial email addresses for the user. Each is created with\n`verification.status = \"verified\"` (BAPI is privileged).\n",
+            "items": {
+              "type": "string",
+              "format": "email",
+              "maxLength": 254
+            },
+            "minItems": 1
+          },
+          "phone_number": {
+            "type": "array",
+            "description": "Reserved for v0.4. Rejected with HTTP 422 in v0.1.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "description": "Plaintext password. Server hashes with the configured `password_hasher`\nbefore storing. Mutually exclusive with `password_digest`.\n"
+          },
+          "password_digest": {
+            "type": "string",
+            "description": "Pre-hashed password (for migrations). Format determined by\n`password_hasher`. Mutually exclusive with `password`.\n"
+          },
+          "password_hasher": {
+            "type": "string",
+            "enum": [
+              "bcrypt",
+              "scrypt",
+              "argon2id",
+              "pbkdf2_sha256",
+              "md5",
+              "sha256"
+            ],
+            "description": "Identifies the algorithm that produced `password_digest`. Required\nwhenever `password_digest` is set.\n"
+          },
+          "skip_password_checks": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, accept a password that doesn't satisfy the environment's\nstrength policy. Useful for migrations.\n"
+          },
+          "skip_password_requirement": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, allow the user to be created with no password even if\nthe environment requires one.\n"
+          },
+          "public_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "private_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "unsafe_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "locale": {
+            "type": "string",
+            "description": "BCP-47 tag."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "description": "Override the user's creation timestamp. Only honored when the\ncaller is migrating users from another system.\n"
+          }
+        }
+      },
+      "UserUpdateRequest": {
+        "type": "object",
+        "description": "Body for `PATCH /v1/users/{user_id}`. Every field is optional;\nunspecified fields are left untouched. Sending `null` clears a\nnullable field.\n",
+        "additionalProperties": false,
+        "properties": {
+          "external_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 255
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 4,
+            "maxLength": 64
+          },
+          "first_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "last_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "primary_email_address_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Must reference an `email_address_id` already attached to this user\nand verified.\n"
+          },
+          "primary_phone_number_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reserved for v0.4. Rejected with HTTP 422 in v0.1."
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "description": "Replace the user's password. Mutually exclusive with `password_digest`.\n"
+          },
+          "password_digest": {
+            "type": "string"
+          },
+          "password_hasher": {
+            "type": "string",
+            "enum": [
+              "bcrypt",
+              "scrypt",
+              "argon2id",
+              "pbkdf2_sha256",
+              "md5",
+              "sha256"
+            ]
+          },
+          "skip_password_checks": {
+            "type": "boolean",
+            "default": false
+          },
+          "sign_out_of_other_sessions": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true` and `password` (or `password_digest`) is also provided,\nrevoke every active session except (optionally) the caller's own.\n"
+          },
+          "public_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "private_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "unsafe_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "locale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "EmailAddressCreateRequest": {
+        "type": "object",
+        "description": "Body for `POST /v1/email_addresses`.",
+        "required": [
+          "user_id",
+          "email_address"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "description": "ID of the `User` that will own this address."
+          },
+          "email_address": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 254
+          },
+          "verified": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, the address is created with\n`verification.status = \"verified\"` and no challenge is issued.\n"
+          },
+          "primary": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true` (and the address is verified), make it the user's\nprimary email address.\n"
+          }
+        }
+      },
+      "EmailAddressUpdateRequest": {
+        "type": "object",
+        "description": "Body for `PATCH /v1/email_addresses/{email_address_id}`.",
+        "additionalProperties": false,
+        "properties": {
+          "verified": {
+            "type": "boolean",
+            "description": "Set to `true` to mark the address verified server-side without\nissuing a challenge. Idempotent.\n"
+          },
+          "primary": {
+            "type": "boolean",
+            "description": "When `true` (and the address is verified), make it the owning\nuser's primary email address.\n"
+          }
+        }
+      },
+      "Client": {
+        "type": "object",
+        "description": "Per-device state container on the FAPI side. Identified by the\n`__client` cookie (or `__authn_db_jwt` query param in cross-origin\ndev). Carries the in-progress sign-in / sign-up state machines and\nthe list of authenticated sessions on this device.\n",
+        "required": [
+          "id",
+          "object",
+          "sessions",
+          "sign_in",
+          "sign_up",
+          "last_active_session_id",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "client"
+          },
+          "sessions": {
+            "type": "array",
+            "description": "Active + recent sessions on this device.",
+            "items": {
+              "$ref": "#/components/schemas/Session"
+            }
+          },
+          "sign_in": {
+            "description": "Current in-progress sign-in attempt, if any.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SignIn"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sign_up": {
+            "description": "Current in-progress sign-up attempt, if any.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SignUp"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "last_active_session_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ID of the session the SDK should treat as \"current\" by default.\nUpdated on every `touch`. `null` when there are no sessions.\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "ClientResponseEnvelope": {
+        "type": "object",
+        "description": "Standard envelope returned by every FAPI **write** operation. The\n`response` field is the resource the operation logically returns\n(e.g. a `SignIn` after `attempt_first_factor`); the `client` field\nis the full updated `Client` so the SDK can refresh its local\ndevice-state cache atomically — no follow-up `GET /v1/client` is\nrequired.\n",
+        "required": [
+          "response",
+          "client"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "response": {
+            "description": "The primary resource for the operation (`SignIn`, `SignUp`,\n`Session`, `User`, `EmailAddress`, …) — schema varies per\noperation.\n",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "client": {
+            "$ref": "#/components/schemas/Client"
+          }
+        }
+      },
+      "Environment": {
+        "type": "object",
+        "description": "Public bootstrap configuration returned by `GET /v1/environment`. The\nSDK fetches this once at boot and uses it to render the right sign-in\nflow, branding, and locale set. No authentication required.\n",
+        "required": [
+          "auth_config",
+          "display_config",
+          "user_settings",
+          "organization_settings",
+          "commerce_settings",
+          "captcha",
+          "localization",
+          "oauth_providers"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "auth_config": {
+            "type": "object",
+            "description": "Allowed authentication strategies and identifier requirements.\nv0.1 returns the password + email-code subset; broader provider\nlists ship in v0.4.\n",
+            "additionalProperties": false,
+            "properties": {
+              "first_factors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "examples": [
+                  [
+                    "password",
+                    "email_code",
+                    "reset_password_email_code",
+                    "ticket"
+                  ]
+                ]
+              },
+              "second_factors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Empty in v0.1 (MFA ships v0.3)."
+              },
+              "identifier_requirements": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "email_address": {
+                    "type": "string",
+                    "enum": [
+                      "required",
+                      "used_for_first_factor",
+                      "off"
+                    ]
+                  },
+                  "phone_number": {
+                    "type": "string",
+                    "enum": [
+                      "required",
+                      "used_for_first_factor",
+                      "off"
+                    ],
+                    "default": "off"
+                  },
+                  "username": {
+                    "type": "string",
+                    "enum": [
+                      "required",
+                      "used_for_first_factor",
+                      "off"
+                    ],
+                    "default": "off"
+                  }
+                }
+              },
+              "sign_up_modes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "public",
+                    "restricted",
+                    "waitlist"
+                  ]
+                }
+              }
+            }
+          },
+          "display_config": {
+            "type": "object",
+            "description": "Branding + post-auth redirect targets shown in the Account Portal.",
+            "additionalProperties": false,
+            "properties": {
+              "application_name": {
+                "type": "string"
+              },
+              "home_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "logo_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "favicon_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "support_email": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "email"
+              },
+              "preferred_sign_in_strategy": {
+                "type": "string",
+                "enum": [
+                  "password",
+                  "otp"
+                ],
+                "default": "password"
+              },
+              "sign_in_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "sign_up_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "after_sign_in_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "after_sign_up_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "branded": {
+                "type": "boolean",
+                "description": "`true` for the free tier (shows \"powered by authn.sh\").",
+                "default": false
+              },
+              "theme": {
+                "type": "object",
+                "description": "Hex colors / radii. Free-form in v0.1.",
+                "additionalProperties": true
+              }
+            }
+          },
+          "user_settings": {
+            "type": "object",
+            "description": "Per-attribute write/verify flags mirrored from the dashboard.\nFlat in v0.1; richer per-attribute matrix lands in v0.5.\n",
+            "additionalProperties": true
+          },
+          "organization_settings": {
+            "type": "object",
+            "description": "Placeholder for organization-aware flows. Always `enabled: false`\nin v0.1.\n",
+            "additionalProperties": true,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          },
+          "commerce_settings": {
+            "type": "object",
+            "description": "Placeholder for billing-aware flows. Always `enabled: false` in v0.1.\n",
+            "additionalProperties": true,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          },
+          "captcha": {
+            "type": "object",
+            "description": "Per-environment CAPTCHA. `provider: none` disables it client-side.\nFields are the public credentials the SDK needs to render the widget.\n",
+            "additionalProperties": false,
+            "properties": {
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "hcaptcha",
+                  "turnstile"
+                ],
+                "default": "none"
+              },
+              "widget_type": {
+                "type": "string",
+                "enum": [
+                  "smart",
+                  "invisible",
+                  "managed"
+                ],
+                "default": "smart"
+              },
+              "public_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "localization": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "default_locale": {
+                "type": "string",
+                "examples": [
+                  "en-US"
+                ]
+              },
+              "supported_locales": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "examples": [
+                  [
+                    "en-US",
+                    "pt-BR",
+                    "fr-FR"
+                  ]
+                ]
+              }
+            }
+          },
+          "oauth_providers": {
+            "type": "array",
+            "description": "Configured OAuth connections. Always `[]` in v0.1; populated when\nproviders ship in v0.4.\n",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "Session": {
+        "type": "object",
+        "description": "An authenticated session for one `User` on one `Client` (device).\nLifecycle:\n\n- `pending` — the SignIn flow created the session but the user hasn't\n  completed all factors yet.\n- `active` — usable.\n- `expired` — past `expire_at`.\n- `ended` — user signed out on this device (`POST /sessions/{id}/end`).\n- `removed` — administratively removed.\n- `replaced` — a new session for the same user/device superseded this one.\n- `revoked` — admin revoked.\n- `abandoned` — never reached `active` and `abandon_at` passed.\n",
+        "required": [
+          "id",
+          "object",
+          "client_id",
+          "user_id",
+          "status",
+          "last_active_at",
+          "expire_at",
+          "abandon_at",
+          "latest_activity",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "session"
+          },
+          "client_id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "active",
+              "expired",
+              "ended",
+              "removed",
+              "replaced",
+              "revoked",
+              "abandoned"
+            ]
+          },
+          "last_active_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "last_active_organization_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Set by `POST /v1/client/sessions/{id}/touch`. Populated once\norganizations land in v0.2.\n"
+          },
+          "expire_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "abandon_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "actor": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true,
+            "description": "Impersonation chain. `null` for end-user sessions; populated when a\nprivileged actor (e.g. dashboard support seat) signs in as another\nuser. Carries `iss`, `sub`, `sid` of the actor's session.\n"
+          },
+          "latest_activity": {
+            "$ref": "#/components/schemas/SessionActivity"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "SessionActivity": {
+        "type": "object",
+        "description": "Latest device fingerprint observed on a `Session`. Populated each time\nthe SDK calls `touch`. Coarse-grained on purpose — no PII beyond the\nIP address, which is hashed when stored.\n",
+        "required": [
+          "id",
+          "object"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "session_activity"
+          },
+          "device_type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "desktop",
+              "mobile",
+              "tablet",
+              "smart_tv",
+              "bot",
+              null
+            ]
+          },
+          "is_mobile": {
+            "type": "boolean",
+            "default": false
+          },
+          "browser_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "browser_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ip_address": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Caller IP, redacted to /24 (IPv4) or /48 (IPv6) at rest."
+          },
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 3166-1 alpha-2 country code."
+          }
+        }
+      },
+      "SignIn": {
+        "type": "object",
+        "description": "In-progress sign-in attempt. The client drives a tiny state machine:\nidentify the user → prepare a first factor → attempt that factor →\n(optionally) prepare/attempt a second factor → `complete`.\n\nv0.1 ships `password` + `email_code` + `reset_password_email_code`\n+ `ticket`. OAuth/SAML/passkey/TOTP land in later milestones.\n",
+        "required": [
+          "id",
+          "object",
+          "status",
+          "supported_identifiers",
+          "supported_first_factors",
+          "supported_second_factors",
+          "first_factor_verification",
+          "second_factor_verification",
+          "identifier",
+          "user_data",
+          "created_session_id",
+          "abandon_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "sign_in_attempt"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "needs_identifier",
+              "needs_first_factor",
+              "needs_second_factor",
+              "needs_new_password",
+              "needs_client_trust",
+              "complete",
+              "abandoned"
+            ],
+            "description": "- `needs_identifier` — caller must supply email/phone/username.\n- `needs_first_factor` — caller must call `prepare_first_factor` then\n  `attempt_first_factor`.\n- `needs_second_factor` — first factor passed; second pending. v0.3+.\n- `needs_new_password` — email-code reset succeeded; caller must\n  `POST /reset_password` with the new password.\n- `needs_client_trust` — environment requires the device pass an\n  out-of-band trust check (geolocation/WAF/captcha).\n- `complete` — `created_session_id` is set; SDK can stop driving.\n- `abandoned` — `abandon_at` passed; create a new sign-in.\n"
+          },
+          "supported_identifiers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "email_address",
+                "phone_number",
+                "username"
+              ]
+            },
+            "description": "Identifier kinds the environment accepts at this step."
+          },
+          "supported_first_factors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "strategy"
+              ],
+              "additionalProperties": true,
+              "properties": {
+                "strategy": {
+                  "type": "string"
+                },
+                "email_address_id": {
+                  "type": "string"
+                },
+                "phone_number_id": {
+                  "type": "string"
+                },
+                "safe_identifier": {
+                  "type": "string",
+                  "description": "Redacted hint shown in UI (e.g. `j***@a***`)."
+                }
+              }
+            },
+            "description": "Concrete first factors that can be prepared."
+          },
+          "supported_second_factors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "description": "Empty in v0.1 (MFA ships in v0.3)."
+          },
+          "first_factor_verification": {
+            "description": "Verification challenge for the chosen first factor, if started.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Verification"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "second_factor_verification": {
+            "description": "Verification challenge for the second factor, if started.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Verification"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "identifier": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Identifier the caller submitted, normalized."
+          },
+          "user_data": {
+            "type": "object",
+            "description": "Public-safe profile preview the client can render before the user\nfinishes auth. Keys mirror `User`'s `first_name`, `last_name`,\n`image_url`, `has_image`. May be `{}` until the identifier resolves.\n",
+            "additionalProperties": true
+          },
+          "created_session_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Set when `status` reaches `complete`. The new `Session` is also\nvisible in the enclosing `Client.sessions[]`.\n"
+          },
+          "abandon_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "SignUp": {
+        "type": "object",
+        "description": "In-progress sign-up attempt. Tracks which fields the environment\nrequires, which the caller has already supplied, which still need\nverification, and the per-attribute verification challenges.\n\nv0.1 supports email + password sign-ups; phone, OAuth, SAML, and\npasskey sign-ups ship in later milestones.\n",
+        "required": [
+          "id",
+          "object",
+          "status",
+          "required_fields",
+          "optional_fields",
+          "missing_fields",
+          "unverified_fields",
+          "verifications",
+          "password_enabled",
+          "unsafe_metadata",
+          "public_metadata",
+          "created_session_id",
+          "created_user_id",
+          "abandon_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "sign_up_attempt"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "missing_requirements",
+              "complete",
+              "transferable",
+              "abandoned"
+            ],
+            "description": "- `missing_requirements` — `missing_fields` or `unverified_fields`\n  is non-empty; caller must `PATCH` to fill / `attempt_verification`\n  to verify.\n- `complete` — `created_user_id` and `created_session_id` are set;\n  SDK can stop driving.\n- `transferable` — an OAuth identity matched but no local user\n  exists; the caller can transfer to sign-up. (v0.4.)\n- `abandoned` — `abandon_at` passed.\n"
+          },
+          "required_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fields the environment requires for sign-up to complete."
+          },
+          "optional_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "missing_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Subset of `required_fields` not yet supplied. When non-empty,\n`status` stays `missing_requirements`.\n"
+          },
+          "unverified_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fields the caller supplied but that need a verification challenge\n(`email_address`, `phone_number`).\n"
+          },
+          "verifications": {
+            "type": "object",
+            "description": "Map of attribute name → `Verification`. Populated by\n`prepare_verification` and updated by `attempt_verification`.\n",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Verification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "examples": [
+              {
+                "email_address": {
+                  "status": "unverified",
+                  "strategy": "email_code",
+                  "attempts": 0,
+                  "expire_at": 1714724000000,
+                  "external_verification_redirect_url": null,
+                  "nonce": null,
+                  "error": null
+                }
+              }
+            ]
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email_address": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email"
+          },
+          "phone_number": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "first_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "password_enabled": {
+            "type": "boolean",
+            "description": "`true` once the caller has set a password on this attempt."
+          },
+          "unsafe_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "public_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "created_session_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_user_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "abandon_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "Invitation": {
+        "type": "object",
+        "description": "Application-level (non-organization) invitation. Each invitation\ncarries a single-use ticket — the recipient clicks `url`, lands on\nthe Account Portal pre-fill page, and either signs up (transferring\nthe ticket into a new `User`) or signs in (linking the address to\nthe existing `User`).\n",
+        "required": [
+          "id",
+          "object",
+          "email_address",
+          "status",
+          "revoked",
+          "url",
+          "public_metadata",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "invitation"
+          },
+          "email_address": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 254
+          },
+          "redirect_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "Where the Account Portal returns the user after they accept. Must\nbe on the redirect-URL allowlist.\n"
+          },
+          "public_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "accepted",
+              "revoked",
+              "expired"
+            ]
+          },
+          "revoked": {
+            "type": "boolean",
+            "default": false
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Click-through URL. Includes the ticket and the\n`__authn_status=sign_up` (or `sign_in`) query so the SDK knows\nwhich flow to start. The full v0.1 query convention lives in\nPLAN §9.7.\n",
+            "examples": [
+              "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up&redirect_url=https%3A%2F%2Fapp.acme.com%2Fwelcome"
+            ]
+          },
+          "expires_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "Unix ms; `null` for invitations that don't expire."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "InvitationCreateRequest": {
+        "type": "object",
+        "description": "Body for `POST /v1/invitations`.",
+        "required": [
+          "email_address"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "email_address": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 254
+          },
+          "redirect_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Must match the redirect-URL allowlist."
+          },
+          "public_metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "notify": {
+            "type": "boolean",
+            "default": true,
+            "description": "When `true`, send the invitation email immediately. Set to `false`\nto mint the ticket without sending email (caller will deliver it\nvia their own channel).\n"
+          },
+          "expires_in_days": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1,
+            "maximum": 365,
+            "description": "Days until `expires_at`. `null` for invitations that don't expire."
+          },
+          "template_slug": {
+            "type": "string",
+            "description": "Reference an alternative invitation email template by slug.\nTemplates ship in v0.5; v0.1 always uses the default template\nand ignores this field.\n"
+          },
+          "ignore_existing": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, allow creating an invitation for an email address\nthat's already attached to a `User`. Default `false` returns\n`422 invitation_for_existing_user`.\n"
+          }
+        }
+      },
+      "InvitationBulkCreateRequest": {
+        "type": "object",
+        "description": "Body for `POST /v1/invitations/bulk`. Atomic across the whole batch:\nif any single invitation fails validation, the entire request is\nrejected and no rows are inserted.\n",
+        "required": [
+          "invitations"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "invitations": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 500,
+            "items": {
+              "$ref": "#/components/schemas/InvitationCreateRequest"
+            }
+          }
+        }
+      },
+      "AllowlistIdentifier": {
+        "type": "object",
+        "description": "A pattern allowed to sign up while the environment is in\n`restricted` mode. The `identifier` is either a literal email\naddress / phone number or a wildcard pattern (`*@example.com`,\n`*@*.example.com`).\n\nWhen a sign-up identifier matches a row here, the user is allowed\nthrough; when `notify: true`, the row is also used as a\nto-be-notified seed for the relevant email template.\n",
+        "required": [
+          "id",
+          "object",
+          "identifier",
+          "notify",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "allowlist_identifier"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Literal email/phone or a wildcard pattern. Wildcard syntax:\n`*@example.com` (any local part), `*@*.example.com` (any\nsubdomain). Phone numbers are E.164.\n",
+            "examples": [
+              "jane@acme.com",
+              "*@acme.com",
+              "*@*.acme.com",
+              "+15551234567"
+            ]
+          },
+          "notify": {
+            "type": "boolean",
+            "default": false,
+            "description": "Send a \"you've been invited\" email when this row is added (only\nmeaningful for literal email addresses).\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "BlocklistIdentifier": {
+        "type": "object",
+        "description": "A pattern that is refused at sign-up. Wildcard syntax matches\n`AllowlistIdentifier`. When both lists match an identifier, the\nblocklist wins.\n",
+        "required": [
+          "id",
+          "object",
+          "identifier",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "blocklist_identifier"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Literal email/phone or a wildcard pattern.",
+            "examples": [
+              "spammer@acme.com",
+              "*@disposable-mailbox.test"
+            ]
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "RedirectUrl": {
+        "type": "object",
+        "description": "An HTTPS URL allowed as a post-flow redirect target. The Account\nPortal and FAPI `redirect_url` parameters are validated against this\nlist to prevent open-redirect abuse.\n",
+        "required": [
+          "id",
+          "object",
+          "url",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "redirect_url"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Origin-and-path URL. Trailing slashes are normalized away. Match\nsemantics: exact origin + path-prefix; query and fragment are\nignored.\n",
+            "examples": [
+              "https://app.acme.com/welcome",
+              "http://localhost:3000/sign-in"
+            ]
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "InstanceSettings": {
+        "type": "object",
+        "description": "Composite read shape returned by `GET /v1/instance`. Covers every\nper-environment knob exposed via BAPI today.\n\nRead-only: `private_metadata` and any secret credential field\n(notably `captcha.secret_key`, `attack_protection.brute_force.secret`)\nare write-only — they're accepted on `PATCH` but **never** returned\nin `GET` responses, so they never reach the dashboard or any audit\nlog unless the caller already supplied them.\n",
+        "required": [
+          "object",
+          "sign_up_modes",
+          "attribute_settings",
+          "restrictions",
+          "attack_protection",
+          "sessions",
+          "paths",
+          "test_mode",
+          "signing_keys",
+          "organizations",
+          "audit_log_retention_days"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "object": {
+            "type": "string",
+            "const": "instance_settings"
+          },
+          "support_email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email"
+          },
+          "enhanced_email_deliverability": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, the instance uses dedicated IPs / DKIM signing for\noutbound mail. v0.1 surfaces the flag but always returns `false`.\n"
+          },
+          "sign_up_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "public",
+                "restricted",
+                "waitlist"
+              ]
+            },
+            "description": "Allowed sign-up modes. `public` is no-allowlist; `restricted`\nrequires an `AllowlistIdentifier` match; `waitlist` defers\naccount creation until the operator approves (post-v0.1).\n"
+          },
+          "attribute_settings": {
+            "type": "object",
+            "description": "Per-attribute write/verify policy for sign-ups.",
+            "additionalProperties": false,
+            "properties": {
+              "email_address": {
+                "$ref": "#/components/schemas/AttributeSetting"
+              },
+              "phone_number": {
+                "$ref": "#/components/schemas/AttributeSetting"
+              },
+              "username": {
+                "$ref": "#/components/schemas/AttributeSetting"
+              },
+              "first_name": {
+                "$ref": "#/components/schemas/AttributeSetting"
+              },
+              "last_name": {
+                "$ref": "#/components/schemas/AttributeSetting"
+              },
+              "password": {
+                "$ref": "#/components/schemas/AttributeSetting"
+              }
+            }
+          },
+          "restrictions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "allowlist_enabled": {
+                "type": "boolean",
+                "default": false
+              },
+              "blocklist_enabled": {
+                "type": "boolean",
+                "default": false
+              },
+              "block_email_subaddresses": {
+                "type": "boolean",
+                "default": false,
+                "description": "When `true`, refuse `local+tag@domain` style addresses to\nstop a single inbox from creating many accounts.\n"
+              },
+              "block_disposable_email_domains": {
+                "type": "boolean",
+                "default": false,
+                "description": "When `true`, refuse addresses on the maintained\ndisposable-domain list (mailinator, tempmail, etc.).\n"
+              },
+              "ignore_dots_for_gmail_addresses": {
+                "type": "boolean",
+                "default": true,
+                "description": "When `true`, `j.doe@gmail.com` and `jdoe@gmail.com` are\ntreated as the same address for uniqueness.\n"
+              }
+            }
+          },
+          "attack_protection": {
+            "type": "object",
+            "description": "Throttles + WAF-ish toggles. Secret credentials are write-only.",
+            "additionalProperties": false,
+            "properties": {
+              "captcha": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "hcaptcha",
+                      "turnstile"
+                    ],
+                    "default": "none"
+                  },
+                  "widget_type": {
+                    "type": "string",
+                    "enum": [
+                      "smart",
+                      "invisible",
+                      "managed"
+                    ],
+                    "default": "smart"
+                  },
+                  "public_key": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Surfaced to the SDK; safe to read."
+                  }
+                }
+              },
+              "brute_force": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "max_attempts": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 100
+                  },
+                  "lockout_duration_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 3600
+                  }
+                }
+              },
+              "device_tracking": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "require_device_trust": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When `true`, sign-in pauses for an out-of-band device\ntrust check before the session activates.\n"
+                  }
+                }
+              }
+            }
+          },
+          "sessions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "lifetime_seconds": {
+                "type": "integer",
+                "minimum": 60,
+                "default": 604800,
+                "description": "Hard ceiling on a session's age."
+              },
+              "inactivity_timeout_seconds": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 60,
+                "description": "Sliding-window expiry. `null` to disable."
+              },
+              "multi_session": {
+                "type": "boolean",
+                "default": true,
+                "description": "When `false`, signing in on a new device ends every other session for the user."
+              },
+              "max_concurrent_sessions_per_client": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 10
+              },
+              "url_based_session_syncing": {
+                "type": "boolean",
+                "default": false,
+                "description": "When `true`, the SDK wires up cross-tab sync via the URL bar\n(used for environments that can't share cookies between\nsubdomains).\n"
+              },
+              "session_token_template": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Default JWT template used by `getSessionToken`. v0.1 ignores\nthis and always issues the built-in template.\n"
+              }
+            }
+          },
+          "paths": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "sign_in_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "sign_up_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "after_sign_in_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "after_sign_up_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "unauthorized_sign_in_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "user_profile_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "create_organization_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "organization_profile_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "after_leave_organization_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "after_create_organization_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              },
+              "home_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "uri"
+              }
+            }
+          },
+          "test_mode": {
+            "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "rejected"
+            ],
+            "description": "`enabled` — `*_test_*` identifiers + the magic `424242` code work\nend-to-end without sending real emails. `disabled` — test\naffordances are off. `rejected` — sign-ins/sign-ups using the\nmagic identifiers are refused (production hardening).\n"
+          },
+          "signing_keys": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "rotation_cadence_days": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 90
+              },
+              "pre_publish_window_seconds": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 86400,
+                "description": "How long a new key sits in JWKS before becoming the active\nsigning key. Lets caches warm up.\n"
+              },
+              "retire_window_seconds": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 604800,
+                "description": "How long a retired key stays in JWKS before being deleted.\n"
+              }
+            }
+          },
+          "organizations": {
+            "type": "object",
+            "description": "Placeholder for organization-level settings. Always\n`enabled: false` in v0.1 — full schema lands in v0.2.\n",
+            "additionalProperties": true,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          },
+          "audit_log_retention_days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3650,
+            "default": 90
+          }
+        }
+      },
+      "AttributeSetting": {
+        "type": "object",
+        "description": "Per-attribute policy embedded in `InstanceSettings.attribute_settings`.\n`verifications[]` lists the strategies the environment will accept\nfor this attribute (e.g. `[\"email_code\"]`).\n",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "When `false`, the attribute is ignored at sign-up entirely."
+          },
+          "required": {
+            "type": "boolean",
+            "default": false,
+            "description": "Sign-up cannot complete without this attribute."
+          },
+          "used_for_first_factor": {
+            "type": "boolean",
+            "default": false
+          },
+          "used_for_second_factor": {
+            "type": "boolean",
+            "default": false
+          },
+          "verifications": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Strategies accepted for verifying this attribute.",
+            "examples": [
+              [
+                "email_code"
+              ],
+              []
+            ]
+          },
+          "verify_at_sign_up": {
+            "type": "boolean",
+            "default": false,
+            "description": "When `true`, sign-up cannot complete until this attribute is\nverified. When `false`, the attribute can be added unverified\nand verified later via `/v1/me/email_addresses/{id}`.\n"
+          }
+        }
+      },
+      "InstanceUpdateRequest": {
+        "type": "object",
+        "description": "Body for `PATCH /v1/instance`. Top-level toggles + writable nested\ngroups. Every field is optional; unspecified groups are left\nuntouched.\n\nSecret credentials (e.g. `attack_protection.captcha.secret_key`,\n`attack_protection.brute_force.secret`) are accepted here but **never**\nreturned by `GET /v1/instance` (write-only).\n",
+        "additionalProperties": false,
+        "properties": {
+          "support_email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email"
+          },
+          "enhanced_email_deliverability": {
+            "type": "boolean"
+          },
+          "sign_up_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "public",
+                "restricted",
+                "waitlist"
+              ]
+            }
+          },
+          "test_mode": {
+            "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "rejected"
+            ]
+          },
+          "paths": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "attribute_settings": {
+            "type": "object",
+            "description": "Same shape as `InstanceSettings.attribute_settings`; you can\npatch any subset of attributes.\n",
+            "additionalProperties": true
+          },
+          "attack_protection": {
+            "type": "object",
+            "description": "Patch any nested toggle. Setting `captcha.secret_key` rotates the\nprovider secret; the new value never appears in subsequent `GET`s.\n",
+            "additionalProperties": true
+          },
+          "sessions": {
+            "type": "object",
+            "description": "Same shape as `InstanceSettings.sessions`.",
+            "additionalProperties": true
+          },
+          "signing_keys": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "audit_log_retention_days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3650
+          }
+        }
+      },
+      "RestrictionsUpdateRequest": {
+        "type": "object",
+        "description": "Body for `PATCH /v1/instance/restrictions`. Same shape as `InstanceSettings.restrictions`.",
+        "additionalProperties": false,
+        "properties": {
+          "allowlist_enabled": {
+            "type": "boolean"
+          },
+          "blocklist_enabled": {
+            "type": "boolean"
+          },
+          "block_email_subaddresses": {
+            "type": "boolean"
+          },
+          "block_disposable_email_domains": {
+            "type": "boolean"
+          },
+          "ignore_dots_for_gmail_addresses": {
+            "type": "boolean"
+          }
+        }
+      },
+      "OrganizationSettingsUpdateRequest": {
+        "type": "object",
+        "description": "Placeholder body for `PATCH /v1/instance/organization_settings`.\nv0.1 only accepts `enabled: false`; the full schema lands in v0.2.\n",
+        "additionalProperties": true,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Always validated as `false` in v0.1. Setting it to `true` returns\n`422 organizations_not_available`.\n"
+          }
+        }
+      },
+      "WebhookEvent": {
+        "type": "object",
+        "description": "Envelope wrapping every webhook delivery. Customers receive this as\nthe JSON body of a `POST` to the configured endpoint, signed via the\nscheme below.\n\n## Signature contract\n\nEach delivery carries three headers:\n\n- `svix-id` — message ID (also the `WebhookDelivery.id`).\n- `svix-timestamp` — unix-second epoch when the server signed the body.\n- `svix-signature` — space-separated list of `v1,<base64>` entries.\n  Multiple entries appear during a `rotateWebhookEndpointSecret`\n  overlap window; verifiers accept any.\n\nVerifier formula:\n\n```\nsigned_payload = \"{svix-id}.{svix-timestamp}.{raw_request_body}\"\ncandidate      = base64(HMAC-SHA256(decoded(signing_secret), signed_payload))\n```\n\nCompare each `v1,<…>` entry constant-time against `candidate`; refuse\nthe request if no match is found, if `svix-timestamp` is more than\n300 seconds away from now, or if any of the three headers are\nmissing.\n",
+        "required": [
+          "id",
+          "object",
+          "type",
+          "data",
+          "timestamp",
+          "instance_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id",
+            "description": "Same as `WebhookDelivery.id` and the `svix-id` header."
+          },
+          "object": {
+            "type": "string",
+            "const": "event"
+          },
+          "type": {
+            "type": "string",
+            "description": "Stable event type identifier. v0.1 ships the events listed below.\nFuture events (organizations, OAuth, enterprise SSO) will be\nadded additively under their own milestones.\n",
+            "enum": [
+              "user.created",
+              "user.updated",
+              "user.deleted",
+              "session.created",
+              "session.ended",
+              "session.removed",
+              "session.revoked",
+              "email.created",
+              "invitation.created",
+              "invitation.accepted",
+              "invitation.revoked"
+            ]
+          },
+          "data": {
+            "description": "The resource snapshot. Concrete shape depends on `type`:\n\n- `user.*` → `User`\n- `session.*` → `Session`\n- `email.*` → `EmailAddress`\n- `invitation.*` → `Invitation`\n",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/User"
+              },
+              {
+                "$ref": "#/components/schemas/Session"
+              },
+              {
+                "$ref": "#/components/schemas/EmailAddress"
+              },
+              {
+                "$ref": "#/components/schemas/Invitation"
+              }
+            ]
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "instance_id": {
+            "type": "string",
+            "description": "ID of the originating `Environment` (so customers can route by tenant)."
+          },
+          "was_test": {
+            "type": "boolean",
+            "default": false,
+            "description": "`true` when the event originated from a test-mode user / session\n(per `Environment.test_mode`). Customers should usually filter\nthese out in production handlers.\n"
+          }
+        }
+      },
+      "WebhookEndpoint": {
+        "type": "object",
+        "description": "A customer-controlled HTTPS endpoint the dispatcher delivers events\nto. Each endpoint has its own `signing_secret` so customers can rotate\none without disturbing others.\n\n`signing_secret` is **write-only**: it appears once on `createWebhookEndpoint`\nand once on `rotateWebhookEndpointSecret`, never on subsequent\n`getWebhookEndpoint` / `listWebhookEndpoints` reads.\n",
+        "required": [
+          "id",
+          "object",
+          "url",
+          "enabled_event_types",
+          "enabled",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "webhook_endpoint"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "HTTPS URL the dispatcher POSTs events to.",
+            "examples": [
+              "https://app.acme.com/webhooks/authn"
+            ]
+          },
+          "signing_secret": {
+            "type": "string",
+            "writeOnly": true,
+            "description": "Per-endpoint HMAC-SHA256 secret. Format: `whsec_<base64>`.\nReturned exactly once, on create and on rotate. Subsequent reads\nomit this field entirely.\n",
+            "examples": [
+              "whsec_dGVzdC1zZWNyZXQ="
+            ]
+          },
+          "signing_secret_prefix": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Read-safe partial fingerprint (first 8 chars of `signing_secret`)\nso the dashboard can display \"ends in `…dGVz`\" without exposing\nthe secret.\n",
+            "examples": [
+              "whsec_dG"
+            ]
+          },
+          "enabled_event_types": {
+            "type": "array",
+            "description": "Subset of the `WebhookEvent.type` enum the endpoint subscribes\nto. `[\"*\"]` means \"every event\"; v0.1 limits the catalog to the\nlist documented on `WebhookEvent`.\n",
+            "items": {
+              "type": "string"
+            },
+            "examples": [
+              [
+                "user.created",
+                "user.deleted",
+                "session.revoked"
+              ]
+            ]
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "When `false`, the dispatcher skips this endpoint without retrying.\nToggled from the dashboard during incidents.\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "WebhookEndpointCreateRequest": {
+        "type": "object",
+        "description": "Body for `POST /v1/webhooks/endpoints`.",
+        "required": [
+          "url",
+          "enabled_event_types"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "HTTPS URL. The dispatcher refuses non-HTTPS targets in production\nenvironments; `http://localhost:*` is allowed in test environments.\n"
+          },
+          "enabled_event_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            },
+            "description": "Initial subscription set. Use `[\"*\"]` to subscribe to every event\nin the v0.1 catalog.\n"
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "WebhookEndpointUpdateRequest": {
+        "type": "object",
+        "description": "Body for `PATCH /v1/webhooks/endpoints/{endpoint_id}`. Every field optional.",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "enabled_event_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WebhookDelivery": {
+        "type": "object",
+        "description": "One attempt at delivering one event to one endpoint. The dispatcher\nretries with exponential backoff on transient failures; each retry\nproduces a new `WebhookDelivery` row sharing the `event_id` of the\nfirst attempt.\n",
+        "required": [
+          "id",
+          "object",
+          "endpoint_id",
+          "event_id",
+          "event_type",
+          "attempt",
+          "succeeded",
+          "created_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "webhook_delivery"
+          },
+          "endpoint_id": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string",
+            "description": "Stable across all retry attempts of the same event."
+          },
+          "event_type": {
+            "type": "string",
+            "description": "Mirrors the `WebhookEvent.type` value being delivered."
+          },
+          "attempt": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based attempt counter; increments on every retry."
+          },
+          "response_status": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 100,
+            "maximum": 599,
+            "description": "HTTP status returned by the endpoint, or `null` for connection failures."
+          },
+          "response_body": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "First 4 KiB of the endpoint's response body (UTF-8 best-effort).\nStored for debugging — never matched against in dispatcher logic.\n"
+          },
+          "next_retry_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "Unix ms; `null` when delivery succeeded or was given up on."
+          },
+          "succeeded": {
+            "type": "boolean",
+            "description": "`true` once the endpoint returns 2xx. Permanent failures\n(`succeeded: false` and `next_retry_at: null`) are kept for\naudit but no longer retried.\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
           }
         }
       }


### PR DESCRIPTION
## Summary

The contract test in `tests/ContractTest.php` has been skipping since SP-2 because `tests/fixtures/openapi.bundled.json` was the OA-1 empty-paths skeleton. Now that OA-2 / OA-3 / OA-4 / OA-5 + [authn-sh/openapi#9](https://github.com/authn-sh/openapi/issues/9) (BAPI sessions admin surface) have all merged, the spec covers every BAPI path the SDK calls — refresh the fixture and flip the test on.

### What changes

- **`tests/fixtures/openapi.bundled.json`** — refreshed from `authn-sh/openapi@main` (65 path items, 89 operations, 36 schemas).
- **`tests/ContractTest.php`** — the original assertions passed a custom message as the second argument to `->toHaveKey(...)` which Pest 3 doesn't accept (the second positional is reserved for nested value matching). Restructured to collect missing paths/methods into one list and assert that's empty, surfacing the same diagnostic in a Pest-3-friendly way.

### Test plan

- [x] `composer test` — **76 pass, 0 skipped, 205 assertions** (was 75 + 1 skipped)
- [x] `composer phpstan` — clean
- [x] `composer pint` — clean
- [ ] CI green on PHP 8.2 / 8.3 / 8.4 / 8.5

### Companion PR

This PR depends on the openapi side: [authn-sh/openapi#11](https://github.com/authn-sh/openapi/pull/11). The fixture in this PR is taken from that PR's branch — once merged the fixture matches `authn-sh/openapi@main`.