### PR TITLE
feat(SP-2): BAPI roles + permissions managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `RolesManager` — `list`, `create`, `get`, `update`, `delete`, `setPermissions`. Accessible via `$client->roles()`.
+- `PermissionsManager` — `list` (read-only). Accessible via `$client->permissions()`.
+- `SystemPermissions` constants for all 12 system permission keys (e.g. `SystemPermissions::ORG_SYS_PROFILE_MANAGE`).
 - `OrganizationsManager` — `list`, `create`, `get`, `update`, `delete`, `members`, `invitations`, `domains`.
 - `OrganizationMembershipsManager` — `list`, `create`, `update`, `delete`. Accessible via `$client->organizations()->members($orgId)`.
 - `OrganizationInvitationsManager` — `list`, `create`, `bulkCreate`, `revoke`. Accessible via `$client->organizations()->invitations($orgId)`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $session = $client->sessions()->revoke('sess_…');
 $invite = $client->invitations()->create(['email_address' => 'a@b.com']);
 ```
 
-Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`, `organizations()`.
+Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`, `organizations()`, `roles()`, `permissions()`.
 
 Organization sub-managers are accessed via `$client->organizations()`:
 
@@ -64,6 +64,23 @@ $invites->revoke('orginv_…');
 $domains = $orgs->domains('org_…');
 $domains->create('acme.com');
 $domains->verify('orgdmn_…');
+```
+
+### Roles and permissions
+
+```php
+use Authn\Sdk\Resources\SystemPermissions;
+
+// Custom roles
+$role = $client->roles()->create(['name' => 'Billing Admin', 'key' => 'org:billing_admin']);
+$client->roles()->setPermissions($role['id'], [
+    SystemPermissions::ORG_SYS_BILLING_READ,
+    SystemPermissions::ORG_SYS_BILLING_MANAGE,
+]);
+$client->roles()->delete($role['id']);
+
+// Read the permissions catalog
+$perms = $client->permissions()->list();
 ```
 
 ### Custom HTTP client / logger

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,7 +10,9 @@ use Authn\Sdk\Resources\BlocklistIdentifiersManager;
 use Authn\Sdk\Resources\InstanceManager;
 use Authn\Sdk\Resources\InvitationsManager;
 use Authn\Sdk\Resources\OrganizationsManager;
+use Authn\Sdk\Resources\PermissionsManager;
 use Authn\Sdk\Resources\RedirectUrlsManager;
+use Authn\Sdk\Resources\RolesManager;
 use Authn\Sdk\Resources\SessionsManager;
 use Authn\Sdk\Resources\UsersManager;
 use Authn\Sdk\Resources\WebhookEndpointsManager;
@@ -92,5 +94,15 @@ final class Client
     public function organizations(): OrganizationsManager
     {
         return new OrganizationsManager($this->transport);
+    }
+
+    public function roles(): RolesManager
+    {
+        return new RolesManager($this->transport);
+    }
+
+    public function permissions(): PermissionsManager
+    {
+        return new PermissionsManager($this->transport);
     }
 }

--- a/src/Resources/PermissionsManager.php
+++ b/src/Resources/PermissionsManager.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class PermissionsManager extends Manager
+{
+    public function list(?ListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/permissions', [
+            'query' => ($params ?? new ListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+}

--- a/src/Resources/RolesManager.php
+++ b/src/Resources/RolesManager.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+use Authn\Sdk\Util\Idempotency;
+
+final class RolesManager extends Manager
+{
+    public function list(?ListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/roles', [
+            'query' => ($params ?? new ListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function create(array $data, ?string $idempotencyKey = null): array
+    {
+        return $this->transport->send('POST', '/v1/roles', [
+            'body' => $data,
+            'idempotencyKey' => $idempotencyKey ?? Idempotency::keyFor($data),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(string $roleId): array
+    {
+        return $this->transport->send('GET', '/v1/roles/' . rawurlencode($roleId));
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public function update(string $roleId, array $data, ?string $idempotencyKey = null): array
+    {
+        return $this->transport->send('PATCH', '/v1/roles/' . rawurlencode($roleId), [
+            'body' => $data,
+            'idempotencyKey' => $idempotencyKey,
+        ]);
+    }
+
+    public function delete(string $roleId): void
+    {
+        $this->transport->send('DELETE', '/v1/roles/' . rawurlencode($roleId));
+    }
+
+    /**
+     * Replaces the role's permission set wholesale.
+     *
+     * @param  list<string>  $permissionKeys
+     * @return array<string, mixed>
+     */
+    public function setPermissions(string $roleId, array $permissionKeys): array
+    {
+        return $this->transport->send('PUT', '/v1/roles/' . rawurlencode($roleId) . '/permissions', [
+            'body' => ['permissions' => $permissionKeys],
+        ]);
+    }
+}

--- a/src/Resources/SystemPermissions.php
+++ b/src/Resources/SystemPermissions.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class SystemPermissions
+{
+    public const ORG_SYS_PROFILE_MANAGE = 'org:sys_profile:manage';
+
+    public const ORG_SYS_PROFILE_DELETE = 'org:sys_profile:delete';
+
+    public const ORG_SYS_MEMBERSHIPS_READ = 'org:sys_memberships:read';
+
+    public const ORG_SYS_MEMBERSHIPS_MANAGE = 'org:sys_memberships:manage';
+
+    public const ORG_SYS_DOMAINS_READ = 'org:sys_domains:read';
+
+    public const ORG_SYS_DOMAINS_MANAGE = 'org:sys_domains:manage';
+
+    public const ORG_SYS_BILLING_READ = 'org:sys_billing:read';
+
+    public const ORG_SYS_BILLING_MANAGE = 'org:sys_billing:manage';
+
+    public const ORG_SYS_SSO_READ = 'org:sys_sso:read';
+
+    public const ORG_SYS_SSO_MANAGE = 'org:sys_sso:manage';
+
+    public const ORG_SYS_PROVISIONING_READ = 'org:sys_provisioning:read';
+
+    public const ORG_SYS_PROVISIONING_MANAGE = 'org:sys_provisioning:manage';
+}

--- a/tests/ContractTest.php
+++ b/tests/ContractTest.php
@@ -78,6 +78,13 @@ it('declares operations for every BAPI endpoint the SDK calls', function (): voi
         ['PATCH', '/v1/organizations/{organization_id}/domains/{domain_id}'],
         ['DELETE', '/v1/organizations/{organization_id}/domains/{domain_id}'],
         ['POST', '/v1/organizations/{organization_id}/domains/{domain_id}/verify'],
+        ['GET', '/v1/roles'],
+        ['POST', '/v1/roles'],
+        ['GET', '/v1/roles/{role_id}'],
+        ['PATCH', '/v1/roles/{role_id}'],
+        ['DELETE', '/v1/roles/{role_id}'],
+        ['PUT', '/v1/roles/{role_id}/permissions'],
+        ['GET', '/v1/permissions'],
     ];
 
     $missing = [];

--- a/tests/Resources/PermissionsManagerTest.php
+++ b/tests/Resources/PermissionsManagerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Resources\ListParams;
+use Authn\Sdk\Resources\PaginatedList;
+use Authn\Sdk\Resources\PermissionsManager;
+use Authn\Sdk\Resources\SystemPermissions;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('lists permissions with pagination', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        'data' => [
+            ['key' => SystemPermissions::ORG_SYS_PROFILE_MANAGE, 'is_system' => true],
+            ['key' => SystemPermissions::ORG_SYS_MEMBERSHIPS_READ, 'is_system' => true],
+        ],
+        'total_count' => 2,
+    ]);
+    $perms = new PermissionsManager($mock->transport());
+
+    $list = $perms->list(new ListParams(limit: 20));
+
+    expect($list)->toBeInstanceOf(PaginatedList::class);
+    expect($list->totalCount)->toBe(2);
+    expect($mock->lastRequest()->getMethod())->toBe('GET');
+    expect((string) $mock->lastRequest()->getUri())->toContain('/v1/permissions');
+    expect((string) $mock->lastRequest()->getUri())->toContain('limit=20');
+});
+
+it('lists all permissions without params', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [], 'total_count' => 0]);
+    $perms = new PermissionsManager($mock->transport());
+
+    $perms->list();
+
+    expect((string) $mock->lastRequest()->getUri())->toContain('/v1/permissions');
+});
+
+it('Client::permissions() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [], 'total_count' => 0]);
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->permissions())->toBeInstanceOf(PermissionsManager::class);
+});

--- a/tests/Resources/RolesManagerTest.php
+++ b/tests/Resources/RolesManagerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Resources\ListParams;
+use Authn\Sdk\Resources\PaginatedList;
+use Authn\Sdk\Resources\RolesManager;
+use Authn\Sdk\Resources\SystemPermissions;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+it('lists roles with pagination', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        'data' => [['id' => 'role_1', 'key' => 'org:admin'], ['id' => 'role_2', 'key' => 'org:member']],
+        'total_count' => 2,
+    ]);
+    $roles = new RolesManager($mock->transport());
+
+    $list = $roles->list(new ListParams(limit: 10));
+
+    expect($list)->toBeInstanceOf(PaginatedList::class);
+    expect($list->totalCount)->toBe(2);
+    expect((string) $mock->lastRequest()->getUri())->toContain('/v1/roles');
+    expect((string) $mock->lastRequest()->getUri())->toContain('limit=10');
+});
+
+it('creates a role with an idempotency key', function (): void {
+    $mock = (new MockTransport)->enqueue(201, ['id' => 'role_1', 'key' => 'org:billing_admin']);
+    $roles = new RolesManager($mock->transport());
+
+    $created = $roles->create(['name' => 'Billing Admin', 'key' => 'org:billing_admin'], idempotencyKey: 'idem-1');
+
+    expect($created['id'])->toBe('role_1');
+    expect($mock->lastRequest()->getMethod())->toBe('POST');
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->toBe('idem-1');
+    expect((string) $mock->lastRequest()->getUri())->toBe('https://api.authn.sh/v1/roles');
+});
+
+it('auto-generates a stable idempotency key when caller omits one', function (): void {
+    $mockA = (new MockTransport)->enqueue(201, ['id' => 'role_a']);
+    $mockB = (new MockTransport)->enqueue(201, ['id' => 'role_a']);
+
+    (new RolesManager($mockA->transport()))->create(['name' => 'Admin', 'key' => 'org:admin']);
+    (new RolesManager($mockB->transport()))->create(['key' => 'org:admin', 'name' => 'Admin']);
+
+    expect($mockA->lastRequest()->getHeaderLine('Idempotency-Key'))
+        ->not->toBe('')
+        ->and($mockA->lastRequest()->getHeaderLine('Idempotency-Key'))
+        ->toBe($mockB->lastRequest()->getHeaderLine('Idempotency-Key'));
+});
+
+it('gets, updates, deletes a role', function (): void {
+    $mock = (new MockTransport)
+        ->enqueue(body: ['id' => 'role_1', 'name' => 'Admin'])
+        ->enqueue(body: ['id' => 'role_1', 'name' => 'Super Admin'])
+        ->enqueue(204);
+
+    $roles = new RolesManager($mock->transport());
+
+    expect($roles->get('role_1')['name'])->toBe('Admin');
+    expect($roles->update('role_1', ['name' => 'Super Admin'])['name'])->toBe('Super Admin');
+    $roles->delete('role_1');
+
+    expect($mock->requestAt(0)->getMethod())->toBe('GET');
+    expect($mock->requestAt(1)->getMethod())->toBe('PATCH');
+    expect($mock->requestAt(2)->getMethod())->toBe('DELETE');
+    expect((string) $mock->requestAt(0)->getUri())->toEndWith('/v1/roles/role_1');
+});
+
+it('setPermissions sends PUT with permissions array', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['id' => 'role_1', 'permissions' => [
+        ['key' => SystemPermissions::ORG_SYS_PROFILE_MANAGE],
+        ['key' => SystemPermissions::ORG_SYS_MEMBERSHIPS_READ],
+    ]]);
+    $roles = new RolesManager($mock->transport());
+
+    $result = $roles->setPermissions('role_1', [
+        SystemPermissions::ORG_SYS_PROFILE_MANAGE,
+        SystemPermissions::ORG_SYS_MEMBERSHIPS_READ,
+    ]);
+
+    expect($result['id'])->toBe('role_1');
+    expect($mock->lastRequest()->getMethod())->toBe('PUT');
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/roles/role_1/permissions');
+    expect((string) $mock->lastRequest()->getBody())
+        ->toBe('{"permissions":["org:sys_profile:manage","org:sys_memberships:read"]}');
+});
+
+it('setPermissions with empty array clears all permissions', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['id' => 'role_1', 'permissions' => []]);
+    $roles = new RolesManager($mock->transport());
+
+    $roles->setPermissions('role_1', []);
+
+    expect((string) $mock->lastRequest()->getBody())->toBe('{"permissions":[]}');
+});
+
+it('system-role mutation surfaces as ApiException', function (): void {
+    $mock = (new MockTransport)->enqueue(422, ['errors' => [['code' => 'system_role_not_editable', 'message' => 'Cannot edit a system role']]]);
+    $roles = new RolesManager($mock->transport());
+
+    expect(fn () => $roles->update('role_sys_admin', ['name' => 'x']))->toThrow(ApiException::class);
+});
+
+it('Client::roles() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [], 'total_count' => 0]);
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->roles())->toBeInstanceOf(RolesManager::class);
+});


### PR DESCRIPTION
## Summary

- Adds `RolesManager` with `list`, `create`, `get`, `update`, `delete`, and `setPermissions` (PUT wholesale replacement)
- Adds `PermissionsManager` with read-only `list`
- Adds `SystemPermissions` constants for all 12 system permission keys
- Wires `Client::roles()` and `Client::permissions()`
- Extends contract test with all new paths

## Test plan

- [ ] `composer test` — 112 tests pass
- [ ] `composer phpstan` — level 10 clean
- [ ] `composer pint` — style clean
- [ ] Custom-role create + setPermissions + delete lifecycle tested
- [ ] System-role mutation surfaces as `ApiException`
- [ ] Idempotency-Key sent on every POST