### PR TITLE
feat(SP-3): typed org claim parsing in VerifiedClaims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `Organization` value object (`id`, `slug`, `role`, `permissions`) with `hasRole()` / `hasPermission()` helpers.
+- `VerifiedClaims->organization` typed as `?Organization`, populated from JWT `org` claim. The deprecated `?array $org` alias is preserved for one minor version.
+- `VerifiedClaims::hasRole(string $key)` / `::hasPermission(string $key)` convenience methods.
 - `RolesManager` — `list`, `create`, `get`, `update`, `delete`, `setPermissions`. Accessible via `$client->roles()`.
 - `PermissionsManager` — `list` (read-only). Accessible via `$client->permissions()`.
 - `SystemPermissions` constants for all 12 system permission keys (e.g. `SystemPermissions::ORG_SYS_PROFILE_MANAGE`).

--- a/README.md
+++ b/README.md
@@ -130,6 +130,32 @@ $claims = $verifier->verify($jwt, expectedAzp: ['https://app.acme.com']);
 
 The verifier fetches the FAPI JWKS once and caches it (PSR-16). On an unknown `kid` it refreshes the JWKS once before failing.
 
+### Organization claim
+
+When the session JWT carries an `org` claim, `$claims->organization` is populated as a typed `Organization` object:
+
+```php
+use Authn\Sdk\Resources\SystemPermissions;
+
+$claims = $verifier->verify($jwt);
+
+if ($claims->organization !== null) {
+    $org = $claims->organization;
+
+    $org->id;          // 'org_…'
+    $org->slug;        // 'acme' or null
+    $org->role;        // 'org:admin' or null
+    $org->permissions; // ['org:sys_billing:read', …]
+
+    $org->hasRole('org:admin');
+    $org->hasPermission(SystemPermissions::ORG_SYS_BILLING_READ);
+}
+
+// Convenience shortcuts directly on VerifiedClaims:
+$claims->hasRole('org:admin');
+$claims->hasPermission(SystemPermissions::ORG_SYS_PROFILE_MANAGE);
+```
+
 ## Verify a webhook
 
 ```php

--- a/src/Tokens/Organization.php
+++ b/src/Tokens/Organization.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Tokens;
+
+final class Organization
+{
+    /**
+     * @param  list<string>  $permissions
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly ?string $slug,
+        public readonly ?string $role,
+        public readonly array $permissions,
+    ) {}
+
+    public function hasRole(string $key): bool
+    {
+        return $this->role === $key;
+    }
+
+    public function hasPermission(string $key): bool
+    {
+        return in_array($key, $this->permissions, true);
+    }
+}

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -258,6 +258,7 @@ final class TokenVerifier
         $actor = isset($claims['act']) && is_array($claims['act']) ? $this->normalizeActor($claims['act']) : null;
         /** @var array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null $org */
         $org = isset($claims['org']) && is_array($claims['org']) ? $this->normalizeOrg($claims['org']) : null;
+        $organization = $org !== null ? $this->buildOrganization($org) : null;
 
         return new VerifiedClaims(
             sub: $sub,
@@ -271,6 +272,7 @@ final class TokenVerifier
             org: $org,
             wasTest: isset($claims['was_test']) && $claims['was_test'] === true,
             raw: $claims,
+            organization: $organization,
         );
     }
 
@@ -319,6 +321,22 @@ final class TokenVerifier
         }
 
         return $out;
+    }
+
+    /**
+     * @param  array{id: string, slg?: string, rol?: string, per?: array<int, string>}  $org
+     */
+    private function buildOrganization(array $org): Organization
+    {
+        /** @var list<string> $permissions */
+        $permissions = array_values(array_unique($org['per'] ?? []));
+
+        return new Organization(
+            id: $org['id'],
+            slug: $org['slg'] ?? null,
+            role: $org['rol'] ?? null,
+            permissions: $permissions,
+        );
     }
 
     private function cacheKey(): string

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -8,7 +8,7 @@ final class VerifiedClaims
 {
     /**
      * @param  array{iss: string, sub: string, sid: string}|null  $actor  impersonation chain
-     * @param  array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null  $org  v0.2 organization claims
+     * @param  array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null  $org  deprecated: use $organization
      * @param  array<string, mixed>  $raw
      */
     public function __construct(
@@ -23,5 +23,16 @@ final class VerifiedClaims
         public readonly ?array $org,
         public readonly bool $wasTest,
         public readonly array $raw,
+        public readonly ?Organization $organization = null,
     ) {}
+
+    public function hasRole(string $key): bool
+    {
+        return $this->organization !== null && $this->organization->hasRole($key);
+    }
+
+    public function hasPermission(string $key): bool
+    {
+        return $this->organization !== null && $this->organization->hasPermission($key);
+    }
 }

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Authn\Sdk\Tests\Support\JwtFixture;
 use Authn\Sdk\Tests\Support\MemoryCache;
 use Authn\Sdk\Tests\Support\StaticBodyClient;
+use Authn\Sdk\Tokens\Organization;
 use Authn\Sdk\Tokens\TokenInvalidException;
 use Authn\Sdk\Tokens\TokenVerifier;
 
@@ -173,8 +174,70 @@ it('parses actor and org claims when present', function (): void {
     $verified = $verifier->verify($fixture->sign($claims));
 
     expect($verified->actor)->toBe(['iss' => 'https://acme.authn.sh', 'sub' => 'user_admin', 'sid' => 'sess_admin']);
+
+    // deprecated array alias still works
     $org = $verified->org;
     expect($org)->not->toBeNull();
     expect($org)->toMatchArray(['id' => 'org_1', 'slg' => 'acme', 'rol' => 'admin']);
     expect($org['per'] ?? null)->toBe(['users:read', 'users:write']);
+
+    // typed value object
+    expect($verified->organization)->toBeInstanceOf(Organization::class);
+    expect($verified->organization?->id)->toBe('org_1');
+    expect($verified->organization?->slug)->toBe('acme');
+    expect($verified->organization?->role)->toBe('admin');
+    expect($verified->organization?->permissions)->toBe(['users:read', 'users:write']);
+});
+
+it('populates organization from the JWT org claim with correct fields', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['org'] = [
+        'id' => 'org_2',
+        'slg' => 'beta-corp',
+        'rol' => 'org:billing_admin',
+        'per' => ['org:sys_billing:read', 'org:sys_billing:manage'],
+    ];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+    $org = $verified->organization;
+
+    expect($org)->toBeInstanceOf(Organization::class);
+    expect($org?->id)->toBe('org_2');
+    expect($org?->slug)->toBe('beta-corp');
+    expect($org?->role)->toBe('org:billing_admin');
+    expect($org?->permissions)->toBe(['org:sys_billing:read', 'org:sys_billing:manage']);
+
+    expect($verified->hasRole('org:billing_admin'))->toBeTrue();
+    expect($verified->hasRole('org:admin'))->toBeFalse();
+    expect($verified->hasPermission('org:sys_billing:read'))->toBeTrue();
+    expect($verified->hasPermission('org:sys_profile:manage'))->toBeFalse();
+});
+
+it('organization is null and hasRole/hasPermission return false when org claim absent', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->organization)->toBeNull();
+    expect($verified->hasRole('admin'))->toBeFalse();
+    expect($verified->hasPermission('org:sys_profile:manage'))->toBeFalse();
+});
+
+it('permissions array is deduped while preserving order', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['org'] = [
+        'id' => 'org_3',
+        'per' => ['perm:a', 'perm:b', 'perm:a', 'perm:c'],
+    ];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->organization?->permissions)->toBe(['perm:a', 'perm:b', 'perm:c']);
 });


### PR DESCRIPTION
## Summary

- Adds `Organization` value object (`id`, `slug`, `role`, `permissions`) with `hasRole()` / `hasPermission()` helpers
- `VerifiedClaims->organization` is now `?Organization`, populated from the JWT `org` claim (`{id, slg, rol, per}`)
- The deprecated `?array $org` field is kept as an alias for one minor version
- `VerifiedClaims::hasRole()` / `::hasPermission()` convenience methods added
- Permissions array is deduplicated while preserving order
- README updated with org claim usage examples

## Test plan

- [ ] `composer test` — 115 tests pass
- [ ] `composer phpstan` — level 10 clean
- [ ] `composer pint` — style clean
- [ ] JWT with `org` claim → typed `Organization` populated correctly
- [ ] JWT without `org` → `organization` is `null`, helpers return `false`
- [ ] Duplicate permissions are deduped in correct order