### PR TITLE
feat(users): verifyTotp() + disableMfa() BAPI MFA admin overrides

### DIFF
--- a/src/Resources/TotpVerificationResult.php
+++ b/src/Resources/TotpVerificationResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class TotpVerificationResult
+{
+    public function __construct(
+        public readonly bool $verified,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            verified: isset($payload['verified']) && $payload['verified'] === true,
+        );
+    }
+}

--- a/src/Resources/UsersManager.php
+++ b/src/Resources/UsersManager.php
@@ -186,4 +186,26 @@ final class UsersManager extends Manager
             '/v1/users/' . rawurlencode($userId) . '/oauth-access-tokens/' . rawurlencode($provider),
         );
     }
+
+    public function verifyTotp(string $userId, string $code): TotpVerificationResult
+    {
+        $payload = $this->transport->send(
+            'POST',
+            '/v1/users/' . rawurlencode($userId) . '/verify-totp',
+            ['body' => ['code' => $code]],
+        );
+
+        return TotpVerificationResult::fromPayload($payload);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function disableMfa(string $userId): array
+    {
+        return $this->transport->send(
+            'DELETE',
+            '/v1/users/' . rawurlencode($userId) . '/mfa',
+        );
+    }
 }

--- a/tests/ContractTest.php
+++ b/tests/ContractTest.php
@@ -84,6 +84,8 @@ it('declares operations for every BAPI endpoint the SDK calls', function (): voi
         ['DELETE', '/v1/roles/{role_id}'],
         ['PUT', '/v1/roles/{role_id}/permissions'],
         ['GET', '/v1/permissions'],
+        ['POST', '/v1/users/{user_id}/verify-totp'],
+        ['DELETE', '/v1/users/{user_id}/mfa'],
     ];
 
     $missing = [];

--- a/tests/Resources/UsersManagerTest.php
+++ b/tests/Resources/UsersManagerTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
 use Authn\Sdk\Http\ResourceNotFoundException;
 use Authn\Sdk\Resources\PaginatedList;
+use Authn\Sdk\Resources\TotpVerificationResult;
 use Authn\Sdk\Resources\UsersListParams;
 use Authn\Sdk\Resources\UsersManager;
 use Authn\Sdk\Tests\Support\MockTransport;
@@ -194,4 +196,63 @@ it('updateMetadata sends a PATCH to /metadata', function (): void {
     expect($request->getMethod())->toBe('PATCH');
     expect((string) $request->getUri())->toEndWith('/v1/users/user_1/metadata');
     expect((string) $request->getBody())->toBe('{"public_metadata":{"plan":"pro"}}');
+});
+
+it('verifyTotp returns TotpVerificationResult with verified=true on success', function (): void {
+    $fixture = (array) json_decode(
+        (string) file_get_contents(__DIR__ . '/../fixtures/users/verify-totp-success.json'),
+        true,
+        flags: JSON_THROW_ON_ERROR,
+    );
+    $mock = (new MockTransport)->enqueue(body: $fixture);
+    $m = new UsersManager($mock->transport());
+
+    $result = $m->verifyTotp('user_1', '542178');
+
+    expect($result)->toBeInstanceOf(TotpVerificationResult::class);
+    expect($result->verified)->toBeTrue();
+    $request = $mock->lastRequest();
+    expect($request->getMethod())->toBe('POST');
+    expect((string) $request->getUri())->toEndWith('/v1/users/user_1/verify-totp');
+    expect((string) $request->getBody())->toBe('{"code":"542178"}');
+});
+
+it('verifyTotp returns TotpVerificationResult with verified=false on incorrect code', function (): void {
+    $fixture = (array) json_decode(
+        (string) file_get_contents(__DIR__ . '/../fixtures/users/verify-totp-incorrect.json'),
+        true,
+        flags: JSON_THROW_ON_ERROR,
+    );
+    $mock = (new MockTransport)->enqueue(body: $fixture);
+    $m = new UsersManager($mock->transport());
+
+    $result = $m->verifyTotp('user_1', '000000');
+
+    expect($result->verified)->toBeFalse();
+});
+
+it('verifyTotp rethrows ApiException on 4xx error responses', function (): void {
+    $mock = (new MockTransport)->enqueue(422, ['errors' => [['code' => 'mfa_not_enabled', 'message' => 'MFA is not enabled']]]);
+    $m = new UsersManager($mock->transport());
+
+    expect(fn () => $m->verifyTotp('user_1', '000000'))->toThrow(ApiException::class);
+});
+
+it('disableMfa sends DELETE to /mfa and returns the updated user', function (): void {
+    $fixture = (array) json_decode(
+        (string) file_get_contents(__DIR__ . '/../fixtures/users/disable-mfa-success.json'),
+        true,
+        flags: JSON_THROW_ON_ERROR,
+    );
+    $mock = (new MockTransport)->enqueue(body: $fixture);
+    $m = new UsersManager($mock->transport());
+
+    $user = $m->disableMfa('user_1');
+
+    expect($user['two_factor_enabled'])->toBeFalse();
+    expect($user['totp_enabled'])->toBeFalse();
+    expect($user['backup_code_enabled'])->toBeFalse();
+    $request = $mock->lastRequest();
+    expect($request->getMethod())->toBe('DELETE');
+    expect((string) $request->getUri())->toEndWith('/v1/users/user_1/mfa');
 });

--- a/tests/fixtures/openapi.bundled.json
+++ b/tests/fixtures/openapi.bundled.json
@@ -1230,6 +1230,138 @@
         }
       }
     },
+    "/v1/users/{user_id}/verify-totp": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "verifyTotp",
+        "summary": "Verify a user's TOTP code (operator override)",
+        "description": "Server-side TOTP check against the user's enrolled `TotpSecret`.\nReturns `200 { verified: true }` on a valid code (within the\n`±1 step` window), `200 { verified: false }` otherwise. Subject to\nthe standard rate-limit bucket; repeated mismatches eventually\nreturn `429`.\n\nUsed by support tooling and SDK callers that need to gate\nsensitive server-side actions on a fresh second-factor proof\nwithout forcing the user back through the FAPI sign-in flow.\nReturns `404` if the user has no enrolled `TotpSecret` and `422`\n(`error_code: mfa_not_enabled`) when the instance has\n`multi_factor.totp.enabled: false`.\n\nThis call does **not** stamp `TotpSecret.verified_at` on its own —\nit's a verification check, not an enrollment confirmation. The\nenrollment confirmation path is the FAPI\n`POST /v1/me/totp/verify` endpoint.\n",
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 8,
+                    "description": "6-digit numeric TOTP from the user's authenticator app."
+                  }
+                }
+              },
+              "examples": {
+                "basic": {
+                  "value": {
+                    "code": "542178"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verification result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "verified"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "verified": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "examples": {
+                  "ok": {
+                    "value": {
+                      "verified": true
+                    }
+                  },
+                  "wrong": {
+                    "value": {
+                      "verified": false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/v1/users/{user_id}/mfa": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Id"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "deleteUserMfa",
+        "summary": "Reset a user's MFA (operator override)",
+        "description": "Operator-driven MFA reset. Deletes the user's `TotpSecret` (if any)\nplus every unconsumed `BackupCode`, flips\n`User.totp_enabled` / `User.backup_code_enabled` /\n`User.two_factor_enabled` to `false`, and stamps\n`User.mfa_disabled_at`.\n\nUsed by support to recover a user who's lost access to their\nauthenticator and exhausted their backup codes. Idempotent —\ncalling on a user with no MFA enrolled returns the user unchanged.\n\nEmits `auth.mfa.totp_removed` and `auth.mfa.backup_codes_removed`\naudit-log events as appropriate, attributed to the operator.\n",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated `User` after the reset.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
     "/v1/email-addresses": {
       "post": {
         "operationId": "createEmailAddress",
@@ -4523,6 +4655,15 @@
                       "organizations": {
                         "enabled": false
                       },
+                      "multi_factor": {
+                        "totp": {
+                          "enabled": true
+                        },
+                        "backup_codes": {
+                          "enabled": true,
+                          "default_count": 10
+                        }
+                      },
                       "audit_log_retention_days": 365
                     }
                   }
@@ -5418,7 +5559,7 @@
       },
       "Challenge": {
         "type": "object",
-        "description": "A single verification challenge bound to a parent resource — a `SignIn`,\n`SignUp`, `EmailAddress`, or `OrganizationDomain`. The parent owns at\nmost one live challenge at a time (`current_challenge_id`). Challenges\nreplace the per-parent `prepare-*` / `attempt-*` / `verify` action\npairs with a uniform sub-resource shape: create the challenge, then\nanswer it (or poll it for out-of-band strategies like `email_link`\nor `domain_dns_txt`).\n\n### Parent reference\n\nExactly one of `sign_in_id`, `sign_up_id`, `email_address_id`,\n`organization_domain_id` is non-null per Challenge — the others are\n`null`. The non-null pointer identifies the parent resource the\nchallenge is verifying. The set of legal `strategy` values is\nparent-specific:\n\n- `SignIn` — `password`, `email_code`, `email_link`,\n  `reset_password_email_code`, `ticket`, `transfer`.\n- `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`.\n- `EmailAddress` — `email_code`, `email_link`. Used by FAPI\n  `/v1/me/email-addresses/{id}/challenges` to verify additional\n  addresses on an already-signed-in user.\n- `OrganizationDomain` — `domain_dns_txt`, `email_code`. Used by\n  BAPI `/v1/organizations/{org}/domains/{id}/challenges` to prove\n  operator control of a domain.\n\n### Lifecycle\n\n- `pending` — challenge issued, no successful answer yet.\n- `verified` — challenge succeeded; the parent advances its state.\n- `transferable` — succeeded against the wrong flow type. The SDK\n  should bounce to the opposite flow with `transfer: true`. v0.2\n  cases (sign-in / sign-up only):\n    1. **Magic-link sign-in for an unknown identifier** — bounce to\n       sign-up via `POST /v1/client/sign-ups { transfer: true }`.\n    2. **Magic-link sign-up for an existing identifier** — bounce to\n       sign-in via `POST /v1/client/sign-ins { transfer: true }`.\n- `failed` — too many wrong attempts; the challenge can no longer be\n  answered. Issue a fresh one to retry.\n- `expired` — `expire_at` is in the past; issue a fresh one.\n\n### Cross-device polling (magic link)\n\n`email_link` is the only sign-in/sign-up strategy that completes\nout-of-band. The click can land on a different device than the one\ndriving the flow, so the originating device polls the focused\nchallenge resource:\n\n1. `POST /sign-ins/{sid}/challenges { strategy: \"email_link\", ... }` —\n   server emails a click-through URL of shape\n   `https://{env_slug}.authn.sh/v1/client/handshake?__authn_ticket=<jwt>&__authn_status=complete`,\n   mirrors that URL into `external_verification_redirect_url`, and\n   returns a polling token in `nonce`.\n2. `POST /sign-ins/{sid}/challenges/{cid}/answer { }` — body has no\n   strategy-specific fields; this commits the SDK to polling but does\n   not synchronously verify anything.\n3. The originating device polls `GET /sign-ins/{sid}/challenges/{cid}`\n   (recommended cadence: every 2s for 60s, then 5s for 5min, then stop).\n   Each poll returns the same `Challenge` until the link is clicked.\n4. The click — possibly on another device — hits `clientHandshake`\n   (`GET /v1/client/handshake?__authn_ticket=…`), which decodes the\n   ticket and flips the challenge to `verified` (or `transferable` for\n   an unknown identifier). The next poll on the originating device\n   sees the new status and completes the flow.\n\nPolling does *not* use SSE or WebSockets — plain HTTP polling keeps the\nFAPI infrastructure simple and works in every browser. Servers may\nrate-limit polling above the recommended cadence (`429`).\n\n### Async DNS verification (`domain_dns_txt`)\n\n`domain_dns_txt` is the strategy for organization-domain proof. The\nflow mirrors magic link in shape but is admin-driven:\n\n1. `POST /organizations/{org}/domains/{did}/challenges { strategy: \"domain_dns_txt\" }`\n   mints a Challenge with `nonce` set to the TXT value the operator\n   must publish under `_authn-challenge.<domain>`. Status starts\n   `pending`.\n2. `POST .../challenges/{cid}/answer { }` (empty body) tells the\n   server to attempt the DNS lookup right now. Returns the\n   Challenge with `status: pending` (the lookup was queued and\n   the record was not yet visible) or `status: verified` (the\n   lookup succeeded synchronously). The server also keeps polling\n   DNS in the background regardless of this hint.\n3. `GET .../challenges/{cid}` polling reflects the live status —\n   it flips to `verified` once the background DNS job confirms,\n   or `expired` once `expire_at` passes without a successful lookup.\n",
+        "description": "A single verification challenge bound to a parent resource — a `SignIn`,\n`SignUp`, `EmailAddress`, or `OrganizationDomain`. The parent owns at\nmost one live challenge at a time (`current_challenge_id`). Challenges\nreplace the per-parent `prepare-*` / `attempt-*` / `verify` action\npairs with a uniform sub-resource shape: create the challenge, then\nanswer it (or poll it for out-of-band strategies like `email_link`\nor `domain_dns_txt`).\n\n### Parent reference\n\nExactly one of `sign_in_id`, `sign_up_id`, `email_address_id`,\n`organization_domain_id` is non-null per Challenge — the others are\n`null`. The non-null pointer identifies the parent resource the\nchallenge is verifying. The set of legal `strategy` values is\nparent-specific:\n\n- `SignIn` (first factor) — `password`, `email_code`, `email_link`,\n  `reset_password_email_code`, `ticket`, `transfer`.\n- `SignIn` (second factor) — `totp`, `backup_code`. Issued only when\n  the parent SignIn is in `needs_second_factor`, scoped to whichever\n  methods the resolved user has enrolled (`SignIn.supported_strategies`\n  narrows to that set).\n- `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`. Sign-up\n  never gains a second factor — MFA enrollment happens after the\n  sign-up completes, on the resulting User.\n- `EmailAddress` — `email_code`, `email_link`. Used by FAPI\n  `/v1/me/email-addresses/{id}/challenges` to verify additional\n  addresses on an already-signed-in user.\n- `OrganizationDomain` — `domain_dns_txt`, `email_code`. Used by\n  BAPI `/v1/organizations/{org}/domains/{id}/challenges` to prove\n  operator control of a domain.\n\n### Lifecycle\n\n- `pending` — challenge issued, no successful answer yet.\n- `verified` — challenge succeeded; the parent advances its state.\n- `transferable` — succeeded against the wrong flow type. The SDK\n  should bounce to the opposite flow with `transfer: true`. v0.2\n  cases (sign-in / sign-up only):\n    1. **Magic-link sign-in for an unknown identifier** — bounce to\n       sign-up via `POST /v1/client/sign-ups { transfer: true }`.\n    2. **Magic-link sign-up for an existing identifier** — bounce to\n       sign-in via `POST /v1/client/sign-ins { transfer: true }`.\n- `failed` — too many wrong attempts; the challenge can no longer be\n  answered. Issue a fresh one to retry.\n- `expired` — `expire_at` is in the past; issue a fresh one.\n\n### Cross-device polling (magic link)\n\n`email_link` is the only sign-in/sign-up strategy that completes\nout-of-band. The click can land on a different device than the one\ndriving the flow, so the originating device polls the focused\nchallenge resource:\n\n1. `POST /sign-ins/{sid}/challenges { strategy: \"email_link\", ... }` —\n   server emails a click-through URL of shape\n   `https://{env_slug}.authn.sh/v1/client/handshake?__authn_ticket=<jwt>&__authn_status=complete`,\n   mirrors that URL into `external_verification_redirect_url`, and\n   returns a polling token in `nonce`.\n2. `POST /sign-ins/{sid}/challenges/{cid}/answer { }` — body has no\n   strategy-specific fields; this commits the SDK to polling but does\n   not synchronously verify anything.\n3. The originating device polls `GET /sign-ins/{sid}/challenges/{cid}`\n   (recommended cadence: every 2s for 60s, then 5s for 5min, then stop).\n   Each poll returns the same `Challenge` until the link is clicked.\n4. The click — possibly on another device — hits `clientHandshake`\n   (`GET /v1/client/handshake?__authn_ticket=…`), which decodes the\n   ticket and flips the challenge to `verified` (or `transferable` for\n   an unknown identifier). The next poll on the originating device\n   sees the new status and completes the flow.\n\nPolling does *not* use SSE or WebSockets — plain HTTP polling keeps the\nFAPI infrastructure simple and works in every browser. Servers may\nrate-limit polling above the recommended cadence (`429`).\n\n### Async DNS verification (`domain_dns_txt`)\n\n`domain_dns_txt` is the strategy for organization-domain proof. The\nflow mirrors magic link in shape but is admin-driven:\n\n1. `POST /organizations/{org}/domains/{did}/challenges { strategy: \"domain_dns_txt\" }`\n   mints a Challenge with `nonce` set to the TXT value the operator\n   must publish under `_authn-challenge.<domain>`. Status starts\n   `pending`.\n2. `POST .../challenges/{cid}/answer { }` (empty body) tells the\n   server to attempt the DNS lookup right now. Returns the\n   Challenge with `status: pending` (the lookup was queued and\n   the record was not yet visible) or `status: verified` (the\n   lookup succeeded synchronously). The server also keeps polling\n   DNS in the background regardless of this hint.\n3. `GET .../challenges/{cid}` polling reflects the live status —\n   it flips to `verified` once the background DNS job confirms,\n   or `expired` once `expire_at` passes without a successful lookup.\n",
         "required": [
           "id",
           "object",
@@ -5497,11 +5638,11 @@
               "second",
               "single"
             ],
-            "description": "Server-assigned at issue time based on the parent's state.\n\n- `first` — first authentication factor on a `SignIn` (typical\n  password / email_code / oauth / magic-link).\n- `second` — second factor for MFA on a `SignIn` (TOTP,\n  backup_code, sms_code, …). v0.3+.\n- `single` — every other case: sign-up email/phone verification,\n  ticket-bound flows, magic-link sign-up, email-address\n  verification, and organization-domain verification. There's no\n  MFA layered on top.\n"
+            "description": "Server-assigned at issue time based on the parent's state.\n\n- `first` — first authentication factor on a `SignIn` (typical\n  password / email_code / oauth / magic-link).\n- `second` — second factor for MFA on a `SignIn` (TOTP,\n  backup_code, sms_code, …). Issued only when the parent SignIn\n  is in `needs_second_factor`. v0.3+.\n- `single` — every other case: sign-up email/phone verification,\n  ticket-bound flows, magic-link sign-up, email-address\n  verification, and organization-domain verification. There's no\n  MFA layered on top. **Note:** TOTP enrollment verification on\n  `/v1/me/totp/verify` is not modelled as a Challenge at all —\n  it's a direct verify call against the enrolling user, not a\n  sub-resource on a parent flow.\n"
           },
           "strategy": {
             "type": "string",
-            "description": "How this challenge is being completed. v0.2 surface:\n\n- `password`, `email_code`, `email_link`,\n  `reset_password_email_code`, `ticket`, `transfer` — sign-in /\n  sign-up.\n- `email_code`, `email_link` — email-address verification on a\n  signed-in user.\n- `domain_dns_txt`, `email_code` — organization-domain\n  verification.\n\nFuture strategies (TOTP, backup_code, SMS, OAuth, passkey) plug\nin here without spec changes.\n",
+            "description": "How this challenge is being completed. v0.3 surface:\n\n- `password`, `email_code`, `email_link`,\n  `reset_password_email_code`, `ticket`, `transfer` — sign-in /\n  sign-up first factor.\n- `totp`, `backup_code` — sign-in second factor (`step: \"second\"`\n  only). Answer with `{ code: \"123456\" }` for `totp` (numeric,\n  6 digits, `±1 step` tolerance) or `{ code: \"abcd-efgh\" }` for\n  `backup_code` (single-use, hashed at rest).\n- `email_code`, `email_link` — email-address verification on a\n  signed-in user.\n- `domain_dns_txt`, `email_code` — organization-domain\n  verification.\n\nFuture strategies (SMS, OAuth, passkey) plug in here without\nspec changes.\n",
             "examples": [
               "password",
               "email_code",
@@ -5510,11 +5651,11 @@
               "ticket",
               "transfer",
               "domain_dns_txt",
+              "totp",
+              "backup_code",
               "oauth_google",
               "phone_code",
-              "passkey",
-              "totp",
-              "backup_code"
+              "passkey"
             ]
           },
           "status": {
@@ -5653,12 +5794,48 @@
             "error": null,
             "created_at": 1714896900000,
             "updated_at": 1714896900000
+          },
+          {
+            "id": "chal_01HKX9SY9V7H7TF8C8K7J9X4ZT",
+            "object": "challenge",
+            "sign_in_id": "sia_01HKX9SY9V7H7TF8C8K7J9X4ZA",
+            "sign_up_id": null,
+            "email_address_id": null,
+            "organization_domain_id": null,
+            "step": "second",
+            "strategy": "totp",
+            "status": "pending",
+            "attempts": 0,
+            "expire_at": 1714724000000,
+            "nonce": null,
+            "external_verification_redirect_url": null,
+            "error": null,
+            "created_at": 1714723000000,
+            "updated_at": 1714723000000
+          },
+          {
+            "id": "chal_01HKX9SY9V7H7TF8C8K7J9X4ZU",
+            "object": "challenge",
+            "sign_in_id": "sia_01HKX9SY9V7H7TF8C8K7J9X4ZA",
+            "sign_up_id": null,
+            "email_address_id": null,
+            "organization_domain_id": null,
+            "step": "second",
+            "strategy": "backup_code",
+            "status": "verified",
+            "attempts": 1,
+            "expire_at": 1714724000000,
+            "nonce": null,
+            "external_verification_redirect_url": null,
+            "error": null,
+            "created_at": 1714723000000,
+            "updated_at": 1714723500000
           }
         ]
       },
       "ChallengeCreateRequest": {
         "type": "object",
-        "description": "Body for `POST /…/challenges` against any parent that owns\nchallenges (`SignIn`, `SignUp`, `EmailAddress`, `OrganizationDomain`).\nPicks a strategy and supplies any fields the strategy needs to\n*issue* the challenge (e.g. which identifier to send the code to,\nwhich redirect URL to bounce back to).\n\nThe answer to the challenge is submitted separately via\n`POST .../challenges/{cid}/answer` with `ChallengeAnswerRequest`.\nStrategies that have nothing to issue (e.g. `password`,\n`domain_dns_txt`) return a `pending` challenge straight away — for\n`domain_dns_txt` the proof token is surfaced in `nonce`; for\n`password` `nonce` stays `null` and the caller proceeds straight\nto `answer`.\n\nPer-parent legal strategies:\n\n- `SignIn` — `password`, `email_code`, `email_link`,\n  `reset_password_email_code`, `ticket`, `transfer`.\n- `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`.\n- `EmailAddress` — `email_code`, `email_link`.\n- `OrganizationDomain` — `domain_dns_txt`, `email_code`.\n",
+        "description": "Body for `POST /…/challenges` against any parent that owns\nchallenges (`SignIn`, `SignUp`, `EmailAddress`, `OrganizationDomain`).\nPicks a strategy and supplies any fields the strategy needs to\n*issue* the challenge (e.g. which identifier to send the code to,\nwhich redirect URL to bounce back to).\n\nThe answer to the challenge is submitted separately via\n`POST .../challenges/{cid}/answer` with `ChallengeAnswerRequest`.\nStrategies that have nothing to issue (e.g. `password`,\n`domain_dns_txt`, `totp`, `backup_code`) return a `pending` challenge\nstraight away — for `domain_dns_txt` the proof token is surfaced in\n`nonce`; for `password`, `totp`, and `backup_code` `nonce` stays\n`null` and the caller proceeds straight to `answer`.\n\nPer-parent legal strategies:\n\n- `SignIn` (first factor) — `password`, `email_code`, `email_link`,\n  `reset_password_email_code`, `ticket`, `transfer`.\n- `SignIn` (second factor) — `totp`, `backup_code`. Only legal when\n  the parent SignIn is in `needs_second_factor`; the server narrows\n  `SignIn.supported_strategies` to the second-factor methods the\n  resolved user has enrolled. `step` on the resulting Challenge is\n  set to `\"second\"`.\n- `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`.\n  Sign-up never gains a second factor.\n- `EmailAddress` — `email_code`, `email_link`.\n- `OrganizationDomain` — `domain_dns_txt`, `email_code`.\n",
         "required": [
           "strategy"
         ],
@@ -5666,7 +5843,7 @@
         "properties": {
           "strategy": {
             "type": "string",
-            "description": "v0.2 surface across all parents:\n`password`, `email_code`, `email_link`, `reset_password_email_code`,\n`ticket`, `transfer`, `domain_dns_txt`. Future strategies (TOTP,\nbackup_code, SMS, OAuth, passkey) plug in here without spec\nchanges.\n",
+            "description": "v0.3 surface across all parents:\n`password`, `email_code`, `email_link`, `reset_password_email_code`,\n`ticket`, `transfer`, `domain_dns_txt`, `totp`, `backup_code`.\nFuture strategies (SMS, OAuth, passkey) plug in here without spec\nchanges.\n",
             "examples": [
               "password",
               "email_code",
@@ -5674,16 +5851,18 @@
               "reset_password_email_code",
               "ticket",
               "transfer",
-              "domain_dns_txt"
+              "domain_dns_txt",
+              "totp",
+              "backup_code"
             ]
           },
           "email_address_id": {
             "type": "string",
-            "description": "For `email_code` / `email_link` first-factor sign-in, the address to\nchallenge. Must be one of `SignIn.supported_strategies`'s implied\nidentifiers. Ignored for sign-up (the address comes from the\nattempt itself) and for the `EmailAddress` parent (the address is\nthe parent itself).\n"
+            "description": "For `email_code` / `email_link` first-factor sign-in, the address to\nchallenge. Must be one of `SignIn.supported_strategies`'s implied\nidentifiers. Ignored for sign-up (the address comes from the\nattempt itself) and for the `EmailAddress` parent (the address is\nthe parent itself). Not used by `totp` / `backup_code` — those\nstrategies are scoped to the resolved user, not an identifier.\n"
           },
           "phone_number_id": {
             "type": "string",
-            "description": "Reserved for `phone_code` (v0.3+)."
+            "description": "Reserved for `phone_code` (v0.4+)."
           },
           "redirect_url": {
             "type": "string",
@@ -5713,12 +5892,18 @@
           },
           {
             "strategy": "domain_dns_txt"
+          },
+          {
+            "strategy": "totp"
+          },
+          {
+            "strategy": "backup_code"
           }
         ]
       },
       "ChallengeAnswerRequest": {
         "type": "object",
-        "description": "Body for `POST /…/challenges/{cid}/answer` against any parent that\nowns challenges (`SignIn`, `SignUp`, `EmailAddress`,\n`OrganizationDomain`). The challenge already knows its strategy;\nthe body carries the strategy-specific answer.\n\n- `password` — `{ password: \"…\" }`.\n- `email_code` / `reset_password_email_code` — `{ code: \"123456\" }`.\n- `ticket` — `{ ticket: \"…\" }`.\n- `email_link` — `{ }` (empty body). This commits the SDK to polling\n  `GET .../challenges/{cid}`; the verification happens out-of-band when\n  the user clicks the magic link. The response is the polled state,\n  not a synchronous success.\n- `domain_dns_txt` — `{ }` (empty body). Hints the server to attempt\n  the DNS lookup right now. The response reflects the immediate\n  result — `verified` if the TXT record was visible, `pending` if\n  the lookup was queued. The server keeps polling DNS in the\n  background regardless.\n- `signature` is reserved for v0.5 (passkey).\n\nOn a `reset_password_email_code` answer the parent SignIn transitions\nto `needs_new_password`; the caller then creates a fresh `password`\nchallenge and answers it with the new password, which advances the\nsign-in to `complete`.\n",
+        "description": "Body for `POST /…/challenges/{cid}/answer` against any parent that\nowns challenges (`SignIn`, `SignUp`, `EmailAddress`,\n`OrganizationDomain`). The challenge already knows its strategy;\nthe body carries the strategy-specific answer.\n\n- `password` — `{ password: \"…\" }`.\n- `email_code` / `reset_password_email_code` — `{ code: \"123456\" }`.\n- `ticket` — `{ ticket: \"…\" }`.\n- `email_link` — `{ }` (empty body). This commits the SDK to polling\n  `GET .../challenges/{cid}`; the verification happens out-of-band when\n  the user clicks the magic link. The response is the polled state,\n  not a synchronous success.\n- `domain_dns_txt` — `{ }` (empty body). Hints the server to attempt\n  the DNS lookup right now. The response reflects the immediate\n  result — `verified` if the TXT record was visible, `pending` if\n  the lookup was queued. The server keeps polling DNS in the\n  background regardless.\n- `totp` — `{ code: \"123456\" }`. 6-digit numeric TOTP. Server checks\n  against the user's stored secret with a `±1 step` (30s) window.\n  Only legal on a `step: \"second\"` Challenge bound to a SignIn.\n- `backup_code` — `{ code: \"abcd-efgh\" }`. Single-use recovery code\n  in `xxxx-xxxx` format. The matching row is marked consumed on\n  success and can never be reused. Only legal on a `step: \"second\"`\n  Challenge bound to a SignIn.\n- `signature` is reserved for v0.5 (passkey).\n\nOn a `reset_password_email_code` answer the parent SignIn transitions\nto `needs_new_password`; the caller then creates a fresh `password`\nchallenge and answers it with the new password, which advances the\nsign-in to `complete`.\n",
         "additionalProperties": false,
         "properties": {
           "password": {
@@ -5742,7 +5927,226 @@
           {
             "code": "542178"
           },
+          {
+            "code": "abcd-efgh"
+          },
           {}
+        ]
+      },
+      "TotpSecret": {
+        "type": "object",
+        "description": "An enrolled TOTP (RFC 6238) shared secret bound to a `User`. A user\nhas at most one `TotpSecret` row at a time — re-enrolling overwrites\nany existing unverified row in place.\n\n### Lifecycle\n\n1. `POST /v1/me/totp` mints a fresh row with `verified_at: null`,\n   returns the plaintext `secret` (base32) plus the prefilled\n   `otpauth_uri` and a server-rendered `qr_code_data_url` so the SDK\n   can render the enrollment QR without a JS dependency. The plaintext\n   secret is **only ever returned in this response** — subsequent\n   reads through `GET /v1/me` surface `User.totp_enabled` but never\n   the secret itself, which is encrypted at rest.\n2. `POST /v1/me/totp/verify` answers with the first generated code;\n   server checks it against the stored secret with a `±1 step`\n   window and stamps `verified_at`. The matching `User` flips\n   `totp_enabled: true`, and `mfa_enabled_at` is set if this is the\n   user's first second factor.\n3. `DELETE /v1/me/totp` removes the row, flips `User.totp_enabled`\n   back to `false`, and stamps `mfa_disabled_at` if no other second\n   factor remains.\n\n### BAPI admin overrides\n\n- `POST /v1/users/{user_id}/verify-totp` lets an operator stamp\n  `verified_at` after they've manually confirmed enrollment (e.g.\n  helping a user through a stuck enrollment).\n- `DELETE /v1/users/{user_id}/mfa` clears the `TotpSecret` (and any\n  `BackupCode` rows) — used to reset MFA when a user has lost access\n  to their authenticator.\n\nThe plaintext `secret` is **not** returned by any BAPI endpoint;\noperators never see the raw secret.\n",
+        "required": [
+          "id",
+          "object",
+          "user_id",
+          "verified_at",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id",
+            "description": "ULID with prefix `totp_`."
+          },
+          "object": {
+            "type": "string",
+            "const": "totp_secret"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "secret": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Base32-encoded shared secret. **Only present in the\n`POST /v1/me/totp` enrollment response.** Subsequent reads omit\nthis field (the secret is encrypted at rest and never re-surfaced).\n",
+            "examples": [
+              "JBSWY3DPEHPK3PXP"
+            ]
+          },
+          "otpauth_uri": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri",
+            "description": "`otpauth://totp/...` URI matching `secret`, suitable for direct\nhand-off to an authenticator app. Only present alongside `secret`\non the enrollment response.\n",
+            "examples": [
+              "otpauth://totp/acme.authn.sh:jane%40acme.com?secret=JBSWY3DPEHPK3PXP&issuer=acme.authn.sh&algorithm=SHA1&digits=6&period=30"
+            ]
+          },
+          "qr_code_data_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`data:image/png;base64,…` payload encoding the `otpauth_uri` as a\nQR code. Renderable in an `<img src>` without a client-side QR\nlibrary. Only present alongside `secret` on the enrollment\nresponse.\n"
+          },
+          "verified_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "Unix-ms timestamp of the first successful TOTP verification.\n`null` while the row is still in unverified-enrollment limbo.\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        "examples": [
+          {
+            "id": "totp_01HKX9SY9V7H7TF8C8K7J9X4ZR",
+            "object": "totp_secret",
+            "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+            "secret": "JBSWY3DPEHPK3PXP",
+            "otpauth_uri": "otpauth://totp/acme.authn.sh:jane%40acme.com?secret=JBSWY3DPEHPK3PXP&issuer=acme.authn.sh&algorithm=SHA1&digits=6&period=30",
+            "qr_code_data_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA…",
+            "verified_at": null,
+            "created_at": 1714896900000,
+            "updated_at": 1714896900000
+          },
+          {
+            "id": "totp_01HKX9SY9V7H7TF8C8K7J9X4ZR",
+            "object": "totp_secret",
+            "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+            "secret": null,
+            "otpauth_uri": null,
+            "qr_code_data_url": null,
+            "verified_at": 1714897200000,
+            "created_at": 1714896900000,
+            "updated_at": 1714897200000
+          }
+        ]
+      },
+      "BackupCode": {
+        "type": "object",
+        "description": "A single-use recovery code paired with a `User`'s second factor.\nBackup codes let a user complete sign-in if they've lost access to\ntheir TOTP authenticator. The plaintext code is **only ever returned\nin the generation response** — at rest the code is hashed (Argon2id),\nmatched against the user's hash list at sign-in time, and marked\nconsumed on first successful answer.\n\n### Lifecycle\n\n1. `POST /v1/me/backup-codes` (re)generates `default_count` plaintext\n   codes (instance-configurable; default 10) and returns the full\n   batch as `codes[]`. The batch supersedes any prior backup-code\n   rows — every old row is deleted server-side before the new batch\n   is stored, so previously-shown codes stop working immediately.\n2. The user copies the codes to a safe place. Subsequent reads\n   never re-surface them.\n3. At sign-in, the user answers a `step: \"second\"` Challenge with\n   `strategy: backup_code` and `{ code: \"abcd-efgh\" }`. The matching\n   row's `consumed_at` is stamped and the code can never be reused.\n4. `DELETE /v1/me/backup-codes` removes every unused code on the\n   user. Combined with `DELETE /v1/me/totp` this is how a user\n   fully disables MFA from the Account Portal.\n5. BAPI `DELETE /v1/users/{user_id}/mfa` is the operator override —\n   clears every TotpSecret + BackupCode and flips\n   `User.mfa_disabled_at`.\n\n### Surface representation\n\nBackup-code rows themselves are not separately enumerated through a\nlist endpoint; the user-facing surface is exactly the one-time\n`BackupCodeBatch` reveal. The `BackupCode` schema is documented for\ncompleteness — it shows up in audit-log payloads, the BAPI admin\nview of MFA state, and the SDK type hierarchy.\n",
+        "required": [
+          "id",
+          "object",
+          "user_id",
+          "consumed_at",
+          "created_at",
+          "updated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Id",
+            "description": "ULID with prefix `bcc_`."
+          },
+          "object": {
+            "type": "string",
+            "const": "backup_code"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "consumed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0,
+            "description": "Unix-ms timestamp of the sign-in answer that consumed this code.\n`null` while the code is still spendable.\n"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "updated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        "examples": [
+          {
+            "id": "bcc_01HKX9SY9V7H7TF8C8K7J9X4ZS",
+            "object": "backup_code",
+            "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+            "consumed_at": null,
+            "created_at": 1714896900000,
+            "updated_at": 1714896900000
+          },
+          {
+            "id": "bcc_01HKX9SY9V7H7TF8C8K7J9X4ZS",
+            "object": "backup_code",
+            "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+            "consumed_at": 1714983300000,
+            "created_at": 1714896900000,
+            "updated_at": 1714983300000
+          }
+        ]
+      },
+      "BackupCodeBatch": {
+        "type": "object",
+        "description": "One-time payload returned by `POST /v1/me/backup-codes`. Carries the\nfreshly-minted plaintext `codes[]` exactly once — they're hashed at\nrest and never re-surfaced. The SDK is expected to render the codes\nimmediately for the user to copy / download / print and to clear the\narray from memory once the user dismisses the reveal modal.\n\nRe-issuing this endpoint replaces every prior code on the user, so the\nmatching `count` reflects the new batch size — there's no merge with\nprevious batches.\n",
+        "required": [
+          "object",
+          "user_id",
+          "count",
+          "codes",
+          "generated_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "object": {
+            "type": "string",
+            "const": "backup_code_batch"
+          },
+          "user_id": {
+            "$ref": "#/components/schemas/Id"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of codes in `codes[]`. Defaults to `multi_factor.backup_codes.default_count` from `InstanceSettings`."
+          },
+          "codes": {
+            "type": "array",
+            "description": "Plaintext recovery codes — formatted `xxxx-xxxx` (8 lowercase\nCrockford-base32 chars with a hyphen at the midpoint). Single-use;\nthe server hashes each one before storage and discards the\nplaintext when the response is sent.\n",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9]{4}-[a-z0-9]{4}$"
+            },
+            "examples": [
+              [
+                "abcd-efgh",
+                "ijkl-mnop",
+                "qrst-uvwx"
+              ]
+            ]
+          },
+          "generated_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          }
+        },
+        "examples": [
+          {
+            "object": "backup_code_batch",
+            "user_id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+            "count": 10,
+            "codes": [
+              "abcd-efgh",
+              "ijkl-mnop",
+              "qrst-uvwx",
+              "yzab-cdef",
+              "ghij-klmn",
+              "opqr-stuv",
+              "wxyz-1234",
+              "5678-90ab",
+              "cdef-ghij",
+              "klmn-opqr"
+            ],
+            "generated_at": 1714896900000
+          }
         ]
       },
       "EmailAddress": {
@@ -6745,6 +7149,7 @@
           "test_mode",
           "signing_keys",
           "organizations",
+          "multi_factor",
           "audit_log_retention_days"
         ],
         "additionalProperties": false,
@@ -7054,6 +7459,53 @@
               }
             }
           },
+          "multi_factor": {
+            "type": "object",
+            "description": "Per-environment MFA strategy gating. The FAPI consults these\nflags before issuing a `totp` / `backup_code` Challenge or\naccepting `POST /v1/me/totp` / `POST /v1/me/backup-codes`. A\nstrategy that's `enabled: false` is omitted from\n`SignIn.supported_strategies` even if a user has stale\nenrollment rows for it (the rows survive the toggle but can't\nbe used to complete sign-in).\n",
+            "additionalProperties": false,
+            "required": [
+              "totp",
+              "backup_codes"
+            ],
+            "properties": {
+              "totp": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "enabled"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When `false`, refuses new TOTP enrollments and excludes\n`totp` from second-factor `supported_strategies`.\n"
+                  }
+                }
+              },
+              "backup_codes": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "enabled",
+                  "default_count"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When `false`, refuses backup-code generation and excludes\n`backup_code` from second-factor `supported_strategies`.\n"
+                  },
+                  "default_count": {
+                    "type": "integer",
+                    "minimum": 4,
+                    "maximum": 24,
+                    "default": 10,
+                    "description": "How many codes `POST /v1/me/backup-codes` mints per\nregeneration request. Bounds chosen so the typical\nprintable card stays readable; raise for environments\nthat want more headroom.\n"
+                  }
+                }
+              }
+            }
+          },
           "audit_log_retention_days": {
             "type": "integer",
             "minimum": 1,
@@ -7161,6 +7613,36 @@
           "signing_keys": {
             "type": "object",
             "additionalProperties": true
+          },
+          "multi_factor": {
+            "type": "object",
+            "description": "Patch any subset of the per-env MFA toggles. Same shape as\n`InstanceSettings.multi_factor` — supply the strategy block(s)\nyou want to update; omitted blocks are left untouched. Setting\na strategy to `enabled: false` keeps existing enrollment rows\nbut stops them from completing sign-in.\n",
+            "additionalProperties": false,
+            "properties": {
+              "totp": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "backup_codes": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "default_count": {
+                    "type": "integer",
+                    "minimum": 4,
+                    "maximum": 24
+                  }
+                }
+              }
+            }
           },
           "audit_log_retention_days": {
             "type": "integer",

--- a/tests/fixtures/users/disable-mfa-success.json
+++ b/tests/fixtures/users/disable-mfa-success.json
@@ -1,0 +1,49 @@
+{
+  "id": "user_01HKX9SY9V7H7TF8C8K7J9X4ZB",
+  "object": "user",
+  "external_id": null,
+  "username": null,
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "image_url": null,
+  "has_image": false,
+  "primary_email_address_id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZC",
+  "primary_phone_number_id": null,
+  "primary_web3_wallet_id": null,
+  "password_enabled": true,
+  "two_factor_enabled": false,
+  "totp_enabled": false,
+  "backup_code_enabled": false,
+  "banned": false,
+  "locked": false,
+  "lockout_expires_in_seconds": null,
+  "verification_attempts_remaining": 100,
+  "created_at": 1714896900000,
+  "updated_at": 1714897200000,
+  "last_sign_in_at": null,
+  "mfa_enabled_at": null,
+  "mfa_disabled_at": 1714897200000,
+  "delete_self_enabled": true,
+  "create_organization_enabled": true,
+  "email_addresses": [
+    {
+      "id": "idn_01HKX9SY9V7H7TF8C8K7J9X4ZC",
+      "object": "email_address",
+      "email_address": "jane@example.com",
+      "reserved": false,
+      "verification": {
+        "status": "verified",
+        "strategy": "email_link"
+      },
+      "linked_to": []
+    }
+  ],
+  "phone_numbers": [],
+  "web3_wallets": [],
+  "external_accounts": [],
+  "enterprise_accounts": [],
+  "passkeys": [],
+  "public_metadata": {},
+  "private_metadata": {},
+  "unsafe_metadata": {}
+}

--- a/tests/fixtures/users/verify-totp-incorrect.json
+++ b/tests/fixtures/users/verify-totp-incorrect.json
@@ -1,0 +1,3 @@
+{
+  "verified": false
+}

--- a/tests/fixtures/users/verify-totp-success.json
+++ b/tests/fixtures/users/verify-totp-success.json
@@ -1,0 +1,3 @@
+{
+  "verified": true
+}


### PR DESCRIPTION
## Summary

- Adds `UsersManager::verifyTotp(string $userId, string $code): TotpVerificationResult` — `POST /v1/users/{user_id}/verify-totp`
- Adds `UsersManager::disableMfa(string $userId): array` — `DELETE /v1/users/{user_id}/mfa`, returns updated `User`
- New `TotpVerificationResult` DTO with `verified: bool`
- Contract test updated with both new endpoints
- Fixture trio added: `verify-totp-success.json`, `verify-totp-incorrect.json`, `disable-mfa-success.json`
- Bundled OpenAPI fixture refreshed from openapi#37

## Test plan

- [ ] `composer test` — 118 tests, all pass
- [ ] `composer phpstan` — no errors
- [ ] `composer pint` — no style violations
- [ ] `verifyTotp` success path returns `TotpVerificationResult` with `verified=true`
- [ ] `verifyTotp` wrong code returns `verified=false`
- [ ] `verifyTotp` 4xx propagates as `ApiException`
- [ ] `disableMfa` sends `DELETE` to `/mfa`, returns user with all MFA flags `false`
- [ ] Contract test confirms both new endpoints in bundled BAPI spec

Closes #18