### PR TITLE
feat(tokens): VerifiedClaims MFA factor-verification age accessors

### DIFF
--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -260,6 +260,8 @@ final class TokenVerifier
         $org = isset($claims['org']) && is_array($claims['org']) ? $this->normalizeOrg($claims['org']) : null;
         $organization = $org !== null ? $this->buildOrganization($org) : null;
 
+        [$firstFactorAgeSeconds, $secondFactorAgeSeconds, $twoFactorVerified] = $this->parseFva($claims);
+
         return new VerifiedClaims(
             sub: $sub,
             sid: $sid,
@@ -273,6 +275,9 @@ final class TokenVerifier
             wasTest: isset($claims['was_test']) && $claims['was_test'] === true,
             raw: $claims,
             organization: $organization,
+            twoFactorVerified: $twoFactorVerified,
+            secondFactorAgeSeconds: $secondFactorAgeSeconds,
+            firstFactorAgeSeconds: $firstFactorAgeSeconds,
         );
     }
 
@@ -337,6 +342,32 @@ final class TokenVerifier
             role: $org['rol'] ?? null,
             permissions: $permissions,
         );
+    }
+
+    /**
+     * Parses the `fva` ([first-factor-age, second-factor-age]) claim.
+     *
+     * Returns [firstFactorAgeSeconds, secondFactorAgeSeconds, twoFactorVerified].
+     * -1 in the JWT means "not verified" → null. twoFactorVerified = fva[1] !== -1.
+     *
+     * @param  array<string, mixed>  $claims
+     * @return array{?int, ?int, bool}
+     */
+    private function parseFva(array $claims): array
+    {
+        if (! isset($claims['fva']) || ! is_array($claims['fva'])) {
+            return [null, null, false];
+        }
+
+        $fva = array_values($claims['fva']);
+        $first = isset($fva[0]) && is_int($fva[0]) ? $fva[0] : null;
+        $second = isset($fva[1]) && is_int($fva[1]) ? $fva[1] : null;
+
+        return [
+            $first !== null && $first !== -1 ? $first : null,
+            $second !== null && $second !== -1 ? $second : null,
+            $second !== null && $second !== -1,
+        ];
     }
 
     private function cacheKey(): string

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -24,6 +24,9 @@ final class VerifiedClaims
         public readonly bool $wasTest,
         public readonly array $raw,
         public readonly ?Organization $organization = null,
+        public readonly bool $twoFactorVerified = false,
+        public readonly ?int $secondFactorAgeSeconds = null,
+        public readonly ?int $firstFactorAgeSeconds = null,
     ) {}
 
     public function hasRole(string $key): bool

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -241,3 +241,56 @@ it('permissions array is deduped while preserving order', function (): void {
 
     expect($verified->organization?->permissions)->toBe(['perm:a', 'perm:b', 'perm:c']);
 });
+
+it('surfaces fva second-factor age and twoFactorVerified when second factor is present', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['fva'] = [30, 120];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->twoFactorVerified)->toBeTrue();
+    expect($verified->firstFactorAgeSeconds)->toBe(30);
+    expect($verified->secondFactorAgeSeconds)->toBe(120);
+});
+
+it('surfaces fva with second-factor age of -1 as twoFactorVerified=false and null age', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['fva'] = [45, -1];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->twoFactorVerified)->toBeFalse();
+    expect($verified->firstFactorAgeSeconds)->toBe(45);
+    expect($verified->secondFactorAgeSeconds)->toBeNull();
+});
+
+it('defaults fva fields to false/null when fva claim is absent', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->twoFactorVerified)->toBeFalse();
+    expect($verified->firstFactorAgeSeconds)->toBeNull();
+    expect($verified->secondFactorAgeSeconds)->toBeNull();
+});
+
+it('maps first-factor-age of -1 to null firstFactorAgeSeconds', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['fva'] = [-1, -1];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->twoFactorVerified)->toBeFalse();
+    expect($verified->firstFactorAgeSeconds)->toBeNull();
+    expect($verified->secondFactorAgeSeconds)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Adds `twoFactorVerified: bool` to `VerifiedClaims` — `true` when `fva[1] !== -1`
- Adds `secondFactorAgeSeconds: ?int` — `fva[1]` exposed as typed nullable int (`-1` → `null`)
- Adds `firstFactorAgeSeconds: ?int` — same shape for `fva[0]`
- `TokenVerifier` parses the `fva` claim during JWT verification; all three fields default to `false`/`null` when the claim is absent (backward-compatible)

## Test plan

- [ ] `composer test` — 122 tests, all pass
- [ ] `composer phpstan` — no errors
- [ ] `composer pint` — no style violations
- [ ] `fva: [30, 120]` → `twoFactorVerified=true`, ages surfaced correctly
- [ ] `fva: [45, -1]` → `twoFactorVerified=false`, `secondFactorAgeSeconds=null`
- [ ] `fva: [-1, -1]` → both ages `null`, `twoFactorVerified=false`
- [ ] no `fva` claim → all defaults (`false`/`null`), existing tests unchanged

Closes #19