### PR TITLE
feat(SP-2): BAPI SmsTemplatesManager

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,6 +15,7 @@ use Authn\Sdk\Resources\PermissionsManager;
 use Authn\Sdk\Resources\RedirectUrlsManager;
 use Authn\Sdk\Resources\RolesManager;
 use Authn\Sdk\Resources\SessionsManager;
+use Authn\Sdk\Resources\SmsTemplatesManager;
 use Authn\Sdk\Resources\UsersManager;
 use Authn\Sdk\Resources\WebhookEndpointsManager;
 use Psr\Http\Client\ClientInterface;
@@ -110,5 +111,10 @@ final class Client
     public function oauthProviders(): OauthProvidersManager
     {
         return new OauthProvidersManager($this->transport);
+    }
+
+    public function smsTemplates(): SmsTemplatesManager
+    {
+        return new SmsTemplatesManager($this->transport);
     }
 }

--- a/src/Http/Transport.php
+++ b/src/Http/Transport.php
@@ -63,6 +63,27 @@ final class Transport
      */
     public function send(string $method, string $path, array $options = []): array
     {
+        $payload = $this->sendAny($method, $path, $options);
+        if (array_is_list($payload)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $payload */
+        return $payload;
+    }
+
+    /**
+     * Same as {@see send} but tolerates top-level JSON arrays in the response
+     * (e.g. `GET /v1/sms-templates` returns `[SmsTemplate, …]`).
+     *
+     * @param  Options  $options
+     * @return array<int|string, mixed>
+     *
+     * @throws ApiException
+     * @throws NetworkException
+     */
+    public function sendAny(string $method, string $path, array $options = []): array
+    {
         $method = strtoupper($method);
         $uri = $this->buildUri($path, $options['query'] ?? []);
 
@@ -129,7 +150,7 @@ final class Transport
             return [];
         }
 
-        return Json::decode((string) $response->getBody());
+        return Json::decodeAny((string) $response->getBody());
     }
 
     /**

--- a/src/Resources/SmsTemplate.php
+++ b/src/Resources/SmsTemplate.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class SmsTemplate
+{
+    public const SLUG_VERIFICATION_CODE = 'verification_code';
+
+    public const SLUG_RESET_PASSWORD_CODE = 'reset_password_code';
+
+    public const SLUG_INVITATION = 'invitation';
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $slug,
+        public readonly string $body,
+        public readonly bool $deliveredByUs,
+        public readonly ?string $fromNumberOverride,
+        public readonly int $createdAt,
+        public readonly int $updatedAt,
+        public readonly array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            id: isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : '',
+            slug: isset($payload['slug']) && is_string($payload['slug']) ? $payload['slug'] : '',
+            body: isset($payload['body']) && is_string($payload['body']) ? $payload['body'] : '',
+            deliveredByUs: (bool) ($payload['delivered_by_us'] ?? true),
+            fromNumberOverride: isset($payload['from_number_override']) && is_string($payload['from_number_override'])
+                ? $payload['from_number_override']
+                : null,
+            createdAt: isset($payload['created_at']) && is_int($payload['created_at']) ? $payload['created_at'] : 0,
+            updatedAt: isset($payload['updated_at']) && is_int($payload['updated_at']) ? $payload['updated_at'] : 0,
+            raw: $payload,
+        );
+    }
+}

--- a/src/Resources/SmsTemplatesManager.php
+++ b/src/Resources/SmsTemplatesManager.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class SmsTemplatesManager extends Manager
+{
+    /**
+     * @return list<SmsTemplate>
+     */
+    public function list(): array
+    {
+        $payload = $this->transport->sendAny('GET', '/v1/sms-templates');
+
+        $rows = [];
+        foreach ($payload as $item) {
+            if (is_array($item)) {
+                /** @var array<string, mixed> $item */
+                $rows[] = SmsTemplate::fromPayload($item);
+            }
+        }
+
+        return $rows;
+    }
+
+    public function get(string $slug): SmsTemplate
+    {
+        $payload = $this->transport->send('GET', '/v1/sms-templates/' . rawurlencode($slug));
+
+        return SmsTemplate::fromPayload($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(string $slug, array $data, ?string $idempotencyKey = null): SmsTemplate
+    {
+        $payload = $this->transport->send(
+            'PATCH',
+            '/v1/sms-templates/' . rawurlencode($slug),
+            [
+                'body' => $data,
+                'idempotencyKey' => $idempotencyKey,
+            ],
+        );
+
+        return SmsTemplate::fromPayload($payload);
+    }
+
+    public function revert(string $slug, ?string $idempotencyKey = null): SmsTemplate
+    {
+        $payload = $this->transport->send(
+            'POST',
+            '/v1/sms-templates/' . rawurlencode($slug) . '/revert',
+            ['idempotencyKey' => $idempotencyKey],
+        );
+
+        return SmsTemplate::fromPayload($payload);
+    }
+}

--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -20,7 +20,9 @@ final class Json
      * Decode a JSON object body into a string-keyed array.
      *
      * Returns an empty array on empty input, invalid JSON, or non-object payloads
-     * (e.g. a JSON array, scalar, or null). All authn.sh API responses are objects.
+     * (e.g. a JSON array, scalar, or null). Most authn.sh API responses are
+     * objects; the few endpoints that return a top-level JSON array
+     * (`GET /v1/sms-templates`) call {@see decodeAny} instead.
      *
      * @return array<string, mixed>
      */
@@ -41,6 +43,34 @@ final class Json
         }
 
         /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * Decode any JSON body (object or top-level array) into an array.
+     *
+     * Returns an empty array on empty input, invalid JSON, or scalar/null
+     * payloads.
+     *
+     * @return array<int|string, mixed>
+     */
+    public static function decodeAny(string $value): array
+    {
+        if ($value === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        /** @var array<int|string, mixed> $decoded */
         return $decoded;
     }
 }

--- a/tests/ContractTest.php
+++ b/tests/ContractTest.php
@@ -92,6 +92,10 @@ it('declares operations for every BAPI endpoint the SDK calls', function (): voi
         ['PATCH', '/v1/oauth-providers/{oauth_provider_id}'],
         ['DELETE', '/v1/oauth-providers/{oauth_provider_id}'],
         ['POST', '/v1/oauth-providers/{oauth_provider_id}/test'],
+        ['GET', '/v1/sms-templates'],
+        ['GET', '/v1/sms-templates/{sms_template_slug}'],
+        ['PATCH', '/v1/sms-templates/{sms_template_slug}'],
+        ['POST', '/v1/sms-templates/{sms_template_slug}/revert'],
     ];
 
     $missing = [];

--- a/tests/Resources/SmsTemplatesManagerTest.php
+++ b/tests/Resources/SmsTemplatesManagerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Resources\SmsTemplate;
+use Authn\Sdk\Resources\SmsTemplatesManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+/**
+ * @return array<string, mixed>
+ */
+function smsTemplatePayload(string $slug = SmsTemplate::SLUG_VERIFICATION_CODE): array
+{
+    return [
+        'id' => 'tmpl_01HKX9SY9V7H7TF8C8K7J9X4ZA',
+        'object' => 'sms_template',
+        'slug' => $slug,
+        'body' => 'Your {{app.name}} code is {{otp_code}}.',
+        'delivered_by_us' => true,
+        'from_number_override' => null,
+        'created_at' => 1_700_000_000_000,
+        'updated_at' => 1_700_000_001_000,
+    ];
+}
+
+it('lists sms templates as an array of SmsTemplate', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        smsTemplatePayload(SmsTemplate::SLUG_VERIFICATION_CODE),
+        smsTemplatePayload(SmsTemplate::SLUG_RESET_PASSWORD_CODE),
+        smsTemplatePayload(SmsTemplate::SLUG_INVITATION),
+    ]);
+    $templates = new SmsTemplatesManager($mock->transport());
+
+    $list = $templates->list();
+
+    expect($list)->toHaveCount(3);
+    expect($list[0])->toBeInstanceOf(SmsTemplate::class);
+    expect($list[0]->slug)->toBe(SmsTemplate::SLUG_VERIFICATION_CODE);
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/sms-templates');
+});
+
+it('gets a single sms template by slug', function (): void {
+    $mock = (new MockTransport)->enqueue(body: smsTemplatePayload());
+    $templates = new SmsTemplatesManager($mock->transport());
+
+    $template = $templates->get(SmsTemplate::SLUG_VERIFICATION_CODE);
+
+    expect($template->slug)->toBe(SmsTemplate::SLUG_VERIFICATION_CODE);
+    expect($template->body)->toContain('{{otp_code}}');
+    expect($template->deliveredByUs)->toBeTrue();
+    expect($template->fromNumberOverride)->toBeNull();
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/sms-templates/verification_code');
+});
+
+it('updates sms template body and surfaces typed result', function (): void {
+    $updated = ['body' => 'New copy {{otp_code}}'] + smsTemplatePayload();
+    $mock = (new MockTransport)->enqueue(body: $updated);
+    $templates = new SmsTemplatesManager($mock->transport());
+
+    $result = $templates->update(SmsTemplate::SLUG_VERIFICATION_CODE, [
+        'body' => 'New copy {{otp_code}}',
+    ], idempotencyKey: 'idem-1');
+
+    expect($result->body)->toBe('New copy {{otp_code}}');
+    expect($mock->lastRequest()->getMethod())->toBe('PATCH');
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->toBe('idem-1');
+    expect((string) $mock->lastRequest()->getBody())->toBe('{"body":"New copy {{otp_code}}"}');
+});
+
+it('reverts sms template via POST to /revert', function (): void {
+    $mock = (new MockTransport)->enqueue(body: smsTemplatePayload());
+    $templates = new SmsTemplatesManager($mock->transport());
+
+    $result = $templates->revert(SmsTemplate::SLUG_VERIFICATION_CODE);
+
+    expect($result)->toBeInstanceOf(SmsTemplate::class);
+    expect($mock->lastRequest()->getMethod())->toBe('POST');
+    expect((string) $mock->lastRequest()->getUri())
+        ->toEndWith('/v1/sms-templates/verification_code/revert');
+});
+
+it('flips delivered_by_us to webhook handoff', function (): void {
+    $payload = ['delivered_by_us' => false] + smsTemplatePayload();
+    $mock = (new MockTransport)->enqueue(body: $payload);
+    $templates = new SmsTemplatesManager($mock->transport());
+
+    $result = $templates->update(SmsTemplate::SLUG_INVITATION, ['delivered_by_us' => false]);
+
+    expect($result->deliveredByUs)->toBeFalse();
+});
+
+it('unknown slug surfaces as ApiException', function (): void {
+    $mock = (new MockTransport)->enqueue(404, [
+        'errors' => [['code' => 'sms_template_not_found', 'message' => 'no such slug', 'long_message' => '...']],
+    ]);
+    $templates = new SmsTemplatesManager($mock->transport());
+
+    expect(fn () => $templates->get('does_not_exist'))->toThrow(ApiException::class);
+});
+
+it('Client::smsTemplates() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: []);
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->smsTemplates())->toBeInstanceOf(SmsTemplatesManager::class);
+});


### PR DESCRIPTION
Closes #25.

## Summary

- Adds `Authn\Sdk\Resources\SmsTemplatesManager` with `list`, `get`, `update`, and `revert` against `/v1/sms-templates`.
- `SmsTemplate` read DTO with `SLUG_VERIFICATION_CODE` / `SLUG_RESET_PASSWORD_CODE` / `SLUG_INVITATION` constants for the three seeded rows.
- `Client::smsTemplates()` accessor.
- `Json::decodeAny()` + `Transport::sendAny()` so the `GET /v1/sms-templates` top-level array decodes cleanly. `Transport::send()` preserves its object-only contract for every existing manager.
- `ContractTest` extended with the four new operations.

## Scope note — PhoneNumbersManager + ExternalAccountsManager deferred

The original SP-2 scope (`#25`) included three managers; this PR ships one. The v0.4 BAPI bundle has no admin paths for `/v1/phone-numbers` or `/v1/external-accounts` — only the FAPI `/v1/me/...` surface from OA-6. The SP-2 issue's "Out of scope" note explicitly anticipated this and asked the implementer to either consume bundle paths or escalate; I escalated.

Filed `authn-sh/openapi#56` (OA-9) to design the missing admin paths. Once that lands, an SP-2b can implement the two remaining managers without churning anything in this PR.

## Test plan

- [x] `vendor/bin/pest` — 137 passed, 397 assertions.
- [x] `vendor/bin/phpstan analyse --no-progress` — clean.
- [x] `vendor/bin/pint --test` — clean.
- [x] New `SmsTemplatesManagerTest` covers list, get, update, revert, the `delivered_by_us: false` webhook handoff, the `sms_template_not_found` 404, and the `Client::smsTemplates()` accessor.
- [x] `ContractTest` exercises every new path against the bundled v0.4-alpha spec.