### PR TITLE
feat(SP-3): VerifiedClaims phoneNumberVerified + defaultSecondFactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `OauthProvidersManager` — BAPI binding for `/v1/oauth-providers` (`list`, `create`, `get`, `update`, `delete`, `test`) plus `OauthProvider`, `OauthProviderTestResult`, `OauthProviderTestError` DTOs and the `OauthProvidersListParams`. Accessible via `$client->oauthProviders()`.
+- `SmsTemplatesManager` — BAPI binding for `/v1/sms-templates` (`list`, `get`, `update(slug, payload)`, `revert(slug)`) plus the `SmsTemplate` DTO with `SLUG_*` constants. Accessible via `$client->smsTemplates()`.
+- `Json::decodeAny()` and `Transport::sendAny()` for endpoints that return a top-level JSON array (`GET /v1/sms-templates`).
+- `VerifiedClaims->phoneNumberVerified: bool` parsed from the `pnv` JWT claim. `false` when the claim is absent.
+- `VerifiedClaims->defaultSecondFactor: ?string` parsed from the `dsf` JWT claim. One of `totp` / `phone_code` / `backup_code`; `null` for absent or unrecognized values.
+- `VerifiedClaims::SECOND_FACTOR_TOTP` / `SECOND_FACTOR_PHONE_CODE` / `SECOND_FACTOR_BACKUP_CODE` constants.
+- `VerifiedClaims::hasVerifiedPhoneNumber()` and `::preferredSecondFactor()` helper methods.
+
 ## [0.3.0] — 2026-05-10
 
 ### Added

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -262,6 +262,9 @@ final class TokenVerifier
 
         [$firstFactorAgeSeconds, $secondFactorAgeSeconds, $twoFactorVerified] = $this->parseFva($claims);
 
+        $phoneNumberVerified = isset($claims['pnv']) && $claims['pnv'] === true;
+        $defaultSecondFactor = $this->parseDefaultSecondFactor($claims);
+
         return new VerifiedClaims(
             sub: $sub,
             sid: $sid,
@@ -278,7 +281,27 @@ final class TokenVerifier
             twoFactorVerified: $twoFactorVerified,
             secondFactorAgeSeconds: $secondFactorAgeSeconds,
             firstFactorAgeSeconds: $firstFactorAgeSeconds,
+            phoneNumberVerified: $phoneNumberVerified,
+            defaultSecondFactor: $defaultSecondFactor,
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $claims
+     */
+    private function parseDefaultSecondFactor(array $claims): ?string
+    {
+        if (! isset($claims['dsf']) || ! is_string($claims['dsf'])) {
+            return null;
+        }
+
+        $valid = [
+            VerifiedClaims::SECOND_FACTOR_TOTP,
+            VerifiedClaims::SECOND_FACTOR_PHONE_CODE,
+            VerifiedClaims::SECOND_FACTOR_BACKUP_CODE,
+        ];
+
+        return in_array($claims['dsf'], $valid, true) ? $claims['dsf'] : null;
     }
 
     /**

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -6,6 +6,12 @@ namespace Authn\Sdk\Tokens;
 
 final class VerifiedClaims
 {
+    public const SECOND_FACTOR_TOTP = 'totp';
+
+    public const SECOND_FACTOR_PHONE_CODE = 'phone_code';
+
+    public const SECOND_FACTOR_BACKUP_CODE = 'backup_code';
+
     /**
      * @param  array{iss: string, sub: string, sid: string}|null  $actor  impersonation chain
      * @param  array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null  $org  deprecated: use $organization
@@ -27,6 +33,8 @@ final class VerifiedClaims
         public readonly bool $twoFactorVerified = false,
         public readonly ?int $secondFactorAgeSeconds = null,
         public readonly ?int $firstFactorAgeSeconds = null,
+        public readonly bool $phoneNumberVerified = false,
+        public readonly ?string $defaultSecondFactor = null,
     ) {}
 
     public function hasRole(string $key): bool
@@ -37,5 +45,15 @@ final class VerifiedClaims
     public function hasPermission(string $key): bool
     {
         return $this->organization !== null && $this->organization->hasPermission($key);
+    }
+
+    public function hasVerifiedPhoneNumber(): bool
+    {
+        return $this->phoneNumberVerified;
+    }
+
+    public function preferredSecondFactor(): ?string
+    {
+        return $this->defaultSecondFactor;
     }
 }

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -294,3 +294,73 @@ it('maps first-factor-age of -1 to null firstFactorAgeSeconds', function (): voi
     expect($verified->firstFactorAgeSeconds)->toBeNull();
     expect($verified->secondFactorAgeSeconds)->toBeNull();
 });
+
+it('surfaces phoneNumberVerified when pnv claim is true', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['pnv'] = true;
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->phoneNumberVerified)->toBeTrue();
+    expect($verified->hasVerifiedPhoneNumber())->toBeTrue();
+});
+
+it('defaults phoneNumberVerified to false when pnv claim is absent', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->phoneNumberVerified)->toBeFalse();
+    expect($verified->hasVerifiedPhoneNumber())->toBeFalse();
+});
+
+it('treats pnv: false as phoneNumberVerified=false', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['pnv'] = false;
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->phoneNumberVerified)->toBeFalse();
+});
+
+it('parses dsf as defaultSecondFactor for each supported factor', function (string $factor): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['dsf'] = $factor;
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->defaultSecondFactor)->toBe($factor);
+    expect($verified->preferredSecondFactor())->toBe($factor);
+})->with(['totp', 'phone_code', 'backup_code']);
+
+it('defaults defaultSecondFactor to null when dsf claim is absent', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->defaultSecondFactor)->toBeNull();
+    expect($verified->preferredSecondFactor())->toBeNull();
+});
+
+it('rejects unknown dsf values as null defaultSecondFactor', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['dsf'] = 'webauthn';
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->defaultSecondFactor)->toBeNull();
+});


### PR DESCRIPTION
Closes #26.

## Summary

Extends `VerifiedClaims` with the two v0.4 MFA-related JWT claims emitted by the FAPI's session-token issuer:

- **`phoneNumberVerified: bool`** — parsed from the `pnv` claim. `false` when absent or non-`true`. Helper: `hasVerifiedPhoneNumber()`.
- **`defaultSecondFactor: ?string`** — parsed from the `dsf` claim. Validated against `{totp, phone_code, backup_code}`; unknown values resolve to `null` so a future server-side factor (e.g. `webauthn`) doesn't silently leak through. Helper: `preferredSecondFactor()`.
- **`SECOND_FACTOR_*` constants** on `VerifiedClaims` for the three valid factor identifiers.

## Server side

The server-side claim emission (`SessionTokenIssuer`) lands separately in the AU-9 / AU-10 path; this PR ships the consumer-side parsing so SDK consumers (sdk-php-laravel SPL-1, downstream apps) can author conditional UI / route guards against the typed claims today. When the FAPI hasn't been bumped yet the claims are absent → both fields fall back to their zero values without any breakage for v0.3 callers.

## Test plan

- [x] `vendor/bin/pest` — 145 passed, 411 assertions (was 137).
- [x] `vendor/bin/phpstan analyse --no-progress` — clean.
- [x] `vendor/bin/pint --test` — clean.
- [x] New `TokenVerifierTest` cases cover `pnv: true` / `false` / absent, all three valid `dsf` values, the unknown-`dsf` → `null` rejection path, and helper-method round-trips.
- [x] CHANGELOG entry under `[Unreleased]` documents the new fields, constants, and helpers.