### PR TITLE
SP-2b: BAPI PhoneNumbersManager + ExternalAccountsManager

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,11 +7,13 @@ namespace Authn\Sdk;
 use Authn\Sdk\Http\Transport;
 use Authn\Sdk\Resources\AllowlistIdentifiersManager;
 use Authn\Sdk\Resources\BlocklistIdentifiersManager;
+use Authn\Sdk\Resources\ExternalAccountsManager;
 use Authn\Sdk\Resources\InstanceManager;
 use Authn\Sdk\Resources\InvitationsManager;
 use Authn\Sdk\Resources\OauthProvidersManager;
 use Authn\Sdk\Resources\OrganizationsManager;
 use Authn\Sdk\Resources\PermissionsManager;
+use Authn\Sdk\Resources\PhoneNumbersManager;
 use Authn\Sdk\Resources\RedirectUrlsManager;
 use Authn\Sdk\Resources\RolesManager;
 use Authn\Sdk\Resources\SessionsManager;
@@ -116,5 +118,15 @@ final class Client
     public function smsTemplates(): SmsTemplatesManager
     {
         return new SmsTemplatesManager($this->transport);
+    }
+
+    public function phoneNumbers(): PhoneNumbersManager
+    {
+        return new PhoneNumbersManager($this->transport);
+    }
+
+    public function externalAccounts(): ExternalAccountsManager
+    {
+        return new ExternalAccountsManager($this->transport);
     }
 }

--- a/src/Resources/ExternalAccount.php
+++ b/src/Resources/ExternalAccount.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class ExternalAccount
+{
+    /**
+     * @param  list<string>  $scopes
+     * @param  array<string, mixed>  $publicMetadata
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $provider,
+        public readonly string $providerKey,
+        public readonly string $providerUserId,
+        public readonly ?string $emailAddress,
+        public readonly array $scopes,
+        public readonly array $publicMetadata,
+        public readonly bool $verified,
+        public readonly ?int $linkedAt,
+        public readonly ?int $lastSignedInAt,
+        public readonly array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        $scopes = $payload['scopes'] ?? [];
+        $publicMetadata = $payload['public_metadata'] ?? [];
+        $publicMetadataMap = [];
+        if (is_array($publicMetadata)) {
+            foreach ($publicMetadata as $k => $v) {
+                if (is_string($k)) {
+                    $publicMetadataMap[$k] = $v;
+                }
+            }
+        }
+
+        return new self(
+            id: isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : '',
+            provider: isset($payload['provider']) && is_string($payload['provider']) ? $payload['provider'] : '',
+            providerKey: isset($payload['provider_key']) && is_string($payload['provider_key']) ? $payload['provider_key'] : '',
+            providerUserId: isset($payload['provider_user_id']) && is_string($payload['provider_user_id']) ? $payload['provider_user_id'] : '',
+            emailAddress: isset($payload['email_address']) && is_string($payload['email_address']) ? $payload['email_address'] : null,
+            scopes: is_array($scopes) ? array_values(array_filter($scopes, 'is_string')) : [],
+            publicMetadata: $publicMetadataMap,
+            verified: (bool) ($payload['verified'] ?? false),
+            linkedAt: isset($payload['linked_at']) && is_int($payload['linked_at']) ? $payload['linked_at'] : null,
+            lastSignedInAt: isset($payload['last_signed_in_at']) && is_int($payload['last_signed_in_at']) ? $payload['last_signed_in_at'] : null,
+            raw: $payload,
+        );
+    }
+}

--- a/src/Resources/ExternalAccountsListParams.php
+++ b/src/Resources/ExternalAccountsListParams.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class ExternalAccountsListParams extends ListParams
+{
+    public function __construct(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $orderBy = null,
+        public ?string $userId = null,
+        public ?string $oauthProviderId = null,
+    ) {
+        parent::__construct($limit, $offset, $orderBy);
+    }
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = parent::toQuery();
+        if ($this->userId !== null) {
+            $q['user_id'] = $this->userId;
+        }
+        if ($this->oauthProviderId !== null) {
+            $q['oauth_provider_id'] = $this->oauthProviderId;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/ExternalAccountsManager.php
+++ b/src/Resources/ExternalAccountsManager.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class ExternalAccountsManager extends Manager
+{
+    public function list(?ExternalAccountsListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/external-accounts', [
+            'query' => ($params ?? new ExternalAccountsListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    public function get(string $externalAccountId): ExternalAccount
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/external-accounts/' . rawurlencode($externalAccountId),
+        );
+
+        return ExternalAccount::fromPayload($payload);
+    }
+
+    public function delete(string $externalAccountId): void
+    {
+        $this->transport->send(
+            'DELETE',
+            '/v1/external-accounts/' . rawurlencode($externalAccountId),
+        );
+    }
+}

--- a/src/Resources/PhoneNumber.php
+++ b/src/Resources/PhoneNumber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class PhoneNumber
+{
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $phoneNumber,
+        public readonly bool $verified,
+        public readonly ?string $currentChallengeId,
+        public readonly bool $isPrimary,
+        public readonly bool $reservedForSecondFactor,
+        public readonly bool $defaultSecondFactor,
+        public readonly ?string $linkedToExternalAccountId,
+        public readonly int $createdAt,
+        public readonly int $updatedAt,
+        public readonly array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            id: isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : '',
+            phoneNumber: isset($payload['phone_number']) && is_string($payload['phone_number']) ? $payload['phone_number'] : '',
+            verified: (bool) ($payload['verified'] ?? false),
+            currentChallengeId: isset($payload['current_challenge_id']) && is_string($payload['current_challenge_id'])
+                ? $payload['current_challenge_id']
+                : null,
+            isPrimary: (bool) ($payload['is_primary'] ?? false),
+            reservedForSecondFactor: (bool) ($payload['reserved_for_second_factor'] ?? false),
+            defaultSecondFactor: (bool) ($payload['default_second_factor'] ?? false),
+            linkedToExternalAccountId: isset($payload['linked_to_external_account_id']) && is_string($payload['linked_to_external_account_id'])
+                ? $payload['linked_to_external_account_id']
+                : null,
+            createdAt: isset($payload['created_at']) && is_int($payload['created_at']) ? $payload['created_at'] : 0,
+            updatedAt: isset($payload['updated_at']) && is_int($payload['updated_at']) ? $payload['updated_at'] : 0,
+            raw: $payload,
+        );
+    }
+}

--- a/src/Resources/PhoneNumbersListParams.php
+++ b/src/Resources/PhoneNumbersListParams.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class PhoneNumbersListParams extends ListParams
+{
+    public function __construct(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $orderBy = null,
+        public ?string $userId = null,
+    ) {
+        parent::__construct($limit, $offset, $orderBy);
+    }
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = parent::toQuery();
+        if ($this->userId !== null) {
+            $q['user_id'] = $this->userId;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/PhoneNumbersManager.php
+++ b/src/Resources/PhoneNumbersManager.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+use Authn\Sdk\Util\Idempotency;
+
+final class PhoneNumbersManager extends Manager
+{
+    public function list(?PhoneNumbersListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/phone-numbers', [
+            'query' => ($params ?? new PhoneNumbersListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function create(array $data, ?string $idempotencyKey = null): PhoneNumber
+    {
+        $payload = $this->transport->send('POST', '/v1/phone-numbers', [
+            'body' => $data,
+            'idempotencyKey' => $idempotencyKey ?? Idempotency::keyFor($data),
+        ]);
+
+        return PhoneNumber::fromPayload($payload);
+    }
+
+    public function get(string $phoneNumberId): PhoneNumber
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/phone-numbers/' . rawurlencode($phoneNumberId),
+        );
+
+        return PhoneNumber::fromPayload($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(string $phoneNumberId, array $data, ?string $idempotencyKey = null): PhoneNumber
+    {
+        $payload = $this->transport->send(
+            'PATCH',
+            '/v1/phone-numbers/' . rawurlencode($phoneNumberId),
+            [
+                'body' => $data,
+                'idempotencyKey' => $idempotencyKey,
+            ],
+        );
+
+        return PhoneNumber::fromPayload($payload);
+    }
+
+    public function delete(string $phoneNumberId): void
+    {
+        $this->transport->send(
+            'DELETE',
+            '/v1/phone-numbers/' . rawurlencode($phoneNumberId),
+        );
+    }
+}


### PR DESCRIPTION
Closes #28.

## Summary

Resolves the SP-2 scope cut from v0.4 — the original SP-2 PR shipped only `SmsTemplatesManager` because the BAPI admin paths for `/v1/phone-numbers` and `/v1/external-accounts` didn't exist in the spec yet. They now do (OA-9 → authn-sh/openapi#57; matching authn controllers at authn-sh/authn#160).

- `PhoneNumbersManager`: list/create/get/update/delete + `PhoneNumbersListParams` (filter by `user_id`). `PhoneNumber` DTO mirrors the API shape.
- `ExternalAccountsManager`: list/get/delete + `ExternalAccountsListParams` (filter by `user_id` + `oauth_provider_id`). `ExternalAccount` DTO covers the public payload only (no token blobs).
- `Client::phoneNumbers()` + `Client::externalAccounts()` accessors.

## Test plan

- [x] 137/137 pest tests still pass
- [x] phpstan + pint clean
- [ ] CI green