### PR TITLE
SP-1: BAPI PasskeysManager + Passkey DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `PasskeysManager` — BAPI binding for `/v1/passkeys` (`list`, `get`, `update(id, nickname)`, `delete`) plus the `Passkey` DTO and `PasskeysListParams` (with `user_id` filter). Accessible via `$client->passkeys()`. Enrollment is FAPI-only (browser ceremony) and is not surfaced here.
+
 ## [0.4.0] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $session = $client->sessions()->revoke('sess_…');
 $invite = $client->invitations()->create(['email_address' => 'a@b.com']);
 ```
 
-Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`, `organizations()`, `roles()`, `permissions()`.
+Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`, `organizations()`, `roles()`, `permissions()`, `oauthProviders()`, `smsTemplates()`, `phoneNumbers()`, `externalAccounts()`, `passkeys()`.
 
 Organization sub-managers are accessed via `$client->organizations()`:
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,6 +12,7 @@ use Authn\Sdk\Resources\InstanceManager;
 use Authn\Sdk\Resources\InvitationsManager;
 use Authn\Sdk\Resources\OauthProvidersManager;
 use Authn\Sdk\Resources\OrganizationsManager;
+use Authn\Sdk\Resources\PasskeysManager;
 use Authn\Sdk\Resources\PermissionsManager;
 use Authn\Sdk\Resources\PhoneNumbersManager;
 use Authn\Sdk\Resources\RedirectUrlsManager;
@@ -128,5 +129,10 @@ final class Client
     public function externalAccounts(): ExternalAccountsManager
     {
         return new ExternalAccountsManager($this->transport);
+    }
+
+    public function passkeys(): PasskeysManager
+    {
+        return new PasskeysManager($this->transport);
     }
 }

--- a/src/Resources/Passkey.php
+++ b/src/Resources/Passkey.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class Passkey
+{
+    /**
+     * @param  list<string>  $transports
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $nickname,
+        public readonly array $transports,
+        public readonly ?string $aaguid,
+        public readonly bool $verified,
+        public readonly ?int $lastUsedAt,
+        public readonly int $createdAt,
+        public readonly int $updatedAt,
+        public readonly array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            id: self::stringField($payload, 'id'),
+            nickname: self::stringField($payload, 'nickname'),
+            transports: self::stringList($payload['transports'] ?? []),
+            aaguid: self::nullableString($payload['aaguid'] ?? null),
+            verified: (bool) ($payload['verified'] ?? false),
+            lastUsedAt: self::nullableInt($payload['last_used_at'] ?? null),
+            createdAt: self::intField($payload, 'created_at'),
+            updatedAt: self::intField($payload, 'updated_at'),
+            raw: $payload,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function stringField(array $payload, string $key): string
+    {
+        $value = $payload[$key] ?? null;
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function intField(array $payload, string $key): int
+    {
+        $value = $payload[$key] ?? null;
+
+        return is_int($value) ? $value : 0;
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
+    }
+
+    private static function nullableInt(mixed $value): ?int
+    {
+        return is_int($value) ? $value : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Resources/PasskeysListParams.php
+++ b/src/Resources/PasskeysListParams.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class PasskeysListParams extends ListParams
+{
+    public function __construct(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $orderBy = null,
+        public ?string $userId = null,
+    ) {
+        parent::__construct($limit, $offset, $orderBy);
+    }
+
+    /**
+     * @return array<string, scalar|null|array<int, scalar|null>>
+     */
+    public function toQuery(): array
+    {
+        $q = parent::toQuery();
+        if ($this->userId !== null) {
+            $q['user_id'] = $this->userId;
+        }
+
+        return $q;
+    }
+}

--- a/src/Resources/PasskeysManager.php
+++ b/src/Resources/PasskeysManager.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class PasskeysManager extends Manager
+{
+    public function list(?PasskeysListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send('GET', '/v1/passkeys', [
+            'query' => ($params ?? new PasskeysListParams)->toQuery(),
+        ]);
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    public function get(string $passkeyId): Passkey
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/passkeys/' . rawurlencode($passkeyId),
+        );
+
+        return Passkey::fromPayload($payload);
+    }
+
+    public function update(string $passkeyId, string $nickname, ?string $idempotencyKey = null): Passkey
+    {
+        $payload = $this->transport->send(
+            'PATCH',
+            '/v1/passkeys/' . rawurlencode($passkeyId),
+            [
+                'body' => ['nickname' => $nickname],
+                'idempotencyKey' => $idempotencyKey,
+            ],
+        );
+
+        return Passkey::fromPayload($payload);
+    }
+
+    public function delete(string $passkeyId): void
+    {
+        $this->transport->send(
+            'DELETE',
+            '/v1/passkeys/' . rawurlencode($passkeyId),
+        );
+    }
+}

--- a/tests/Resources/PasskeysManagerTest.php
+++ b/tests/Resources/PasskeysManagerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Resources\PaginatedList;
+use Authn\Sdk\Resources\Passkey;
+use Authn\Sdk\Resources\PasskeysListParams;
+use Authn\Sdk\Resources\PasskeysManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+/**
+ * @return array<string, mixed>
+ */
+function yubikeyPasskeyPayload(): array
+{
+    return [
+        'id' => 'pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA',
+        'object' => 'passkey',
+        'nickname' => 'YubiKey 5C',
+        'transports' => ['usb', 'nfc'],
+        'aaguid' => 'ee882879-721c-4913-9775-3dfcce97072a',
+        'verified' => true,
+        'last_used_at' => 1_714_896_500_000,
+        'created_at' => 1_714_723_000_000,
+        'updated_at' => 1_714_896_500_000,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function touchIdPasskeyPayload(): array
+{
+    return [
+        'id' => 'pkey_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'object' => 'passkey',
+        'nickname' => 'MacBook Touch ID',
+        'transports' => ['internal', 'hybrid'],
+        'aaguid' => null,
+        'verified' => true,
+        'last_used_at' => null,
+        'created_at' => 1_714_724_000_000,
+        'updated_at' => 1_714_724_000_000,
+    ];
+}
+
+it('lists passkeys with pagination and a user_id filter', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        'data' => [yubikeyPasskeyPayload(), touchIdPasskeyPayload()],
+        'total_count' => 2,
+    ]);
+    $passkeys = new PasskeysManager($mock->transport());
+
+    $list = $passkeys->list(new PasskeysListParams(limit: 10, userId: 'user_01HKX9SY9V7H7TF8C8K7J9X4ZZ'));
+
+    expect($list)->toBeInstanceOf(PaginatedList::class);
+    expect($list->totalCount)->toBe(2);
+    expect((string) $mock->lastRequest()->getUri())->toContain('/v1/passkeys');
+    expect((string) $mock->lastRequest()->getUri())->toContain('limit=10');
+    expect((string) $mock->lastRequest()->getUri())
+        ->toContain('user_id=user_01HKX9SY9V7H7TF8C8K7J9X4ZZ');
+});
+
+it('gets, renames, deletes a passkey', function (): void {
+    $payload = yubikeyPasskeyPayload();
+    $renamed = ['nickname' => 'Work YubiKey'] + $payload;
+
+    $mock = (new MockTransport)
+        ->enqueue(body: $payload)
+        ->enqueue(body: $renamed)
+        ->enqueue(204);
+
+    $passkeys = new PasskeysManager($mock->transport());
+
+    $got = $passkeys->get('pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+    expect($got)->toBeInstanceOf(Passkey::class);
+    expect($got->nickname)->toBe('YubiKey 5C');
+    expect($got->transports)->toBe(['usb', 'nfc']);
+    expect($got->aaguid)->toBe('ee882879-721c-4913-9775-3dfcce97072a');
+    expect($got->verified)->toBeTrue();
+    expect($got->lastUsedAt)->toBe(1_714_896_500_000);
+
+    $updated = $passkeys->update('pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA', 'Work YubiKey');
+    expect($updated->nickname)->toBe('Work YubiKey');
+
+    $passkeys->delete('pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+
+    expect($mock->requestAt(0)->getMethod())->toBe('GET');
+    expect($mock->requestAt(1)->getMethod())->toBe('PATCH');
+    expect($mock->requestAt(2)->getMethod())->toBe('DELETE');
+    expect((string) $mock->requestAt(0)->getUri())
+        ->toEndWith('/v1/passkeys/pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+});
+
+it('parses platform passkey payload with null aaguid and null last_used_at', function (): void {
+    $mock = (new MockTransport)->enqueue(body: touchIdPasskeyPayload());
+    $passkeys = new PasskeysManager($mock->transport());
+
+    $got = $passkeys->get('pkey_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    expect($got->aaguid)->toBeNull();
+    expect($got->lastUsedAt)->toBeNull();
+    expect($got->transports)->toBe(['internal', 'hybrid']);
+});
+
+it('passes an idempotency key on rename when provided', function (): void {
+    $mock = (new MockTransport)->enqueue(body: yubikeyPasskeyPayload());
+    $passkeys = new PasskeysManager($mock->transport());
+
+    $passkeys->update('pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA', 'YubiKey 5C', idempotencyKey: 'idem-1');
+
+    expect($mock->lastRequest()->getMethod())->toBe('PATCH');
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->toBe('idem-1');
+});
+
+it('surfaces server errors as ApiException', function (): void {
+    $mock = (new MockTransport)->enqueue(404, [
+        'errors' => [['code' => 'passkey_not_found', 'message' => 'not found', 'long_message' => '...']],
+    ]);
+    $passkeys = new PasskeysManager($mock->transport());
+
+    expect(fn () => $passkeys->get('pkey_missing'))->toThrow(ApiException::class);
+});
+
+it('Client::passkeys() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [], 'total_count' => 0]);
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->passkeys())->toBeInstanceOf(PasskeysManager::class);
+});


### PR DESCRIPTION
## Summary

Adds the admin-side `PasskeysManager` to `sdk-php`, binding the BAPI `/v1/passkeys` surface that landed with AU-3.

- `Passkey` DTO — public-surface fields per OA-1 (`id`, `nickname`, `transports[]`, `aaguid`, `verified`, `last_used_at`, `created_at`, `updated_at`). Server-only WebAuthn columns (`credential_id`, `public_key`, `sign_count`) intentionally never appear in payloads.
- `PasskeysListParams` extends `ListParams` with a `user_id` filter.
- `PasskeysManager` — `list`, `get`, `update(id, nickname)`, `delete`. Enrollment is FAPI-only (live browser ceremony) and is not surfaced here.
- `Client::passkeys()` accessor.

## Test plan

- [x] `composer test` — 151 passed (6 new passkey tests, 434 assertions)
- [x] `composer phpstan` — clean
- [x] `composer pint` — clean

Test coverage:
- List pagination + `user_id` filter on `GET /v1/passkeys`
- Get / rename / delete round-trip
- Platform-passkey payload with null `aaguid` and null `last_used_at`
- Idempotency-key forwarding on `PATCH`
- 404 surfacing as `ApiException`
- `Client::passkeys()` wiring

Closes #33