### PR TITLE
SP-2: BAPI AppearanceManager + LocalizationManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `PasskeysManager` — BAPI binding for `/v1/passkeys` (`list`, `get`, `update(id, nickname)`, `delete`) plus the `Passkey` DTO and `PasskeysListParams` (with `user_id` filter). Accessible via `$client->passkeys()`. Enrollment is FAPI-only (browser ceremony) and is not surfaced here.
+- `AppearanceManager` — BAPI binding for `/v1/instance/appearance` (`get`, `put`, `patch`) plus the `Appearance` DTO (`variables`, `elements`, `layout`). Accessible via `$client->appearance()`. `patch()` accepts a sparse array; the server deep-merges supplied keys.
+- `LocalizationManager` — BAPI binding for `/v1/instance/localization` (`get`, `put`, `patch`) plus the `Localization` DTO (`default_locale`, `fallback_locale`, `supported_locales[]`, `overrides`). Accessible via `$client->localization()`. `patch()` supports the sparse per-key override merge: passing `null` for a key under `overrides[locale]` removes that single override.
 
 ## [0.4.0] — 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $session = $client->sessions()->revoke('sess_…');
 $invite = $client->invitations()->create(['email_address' => 'a@b.com']);
 ```
 
-Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`, `organizations()`, `roles()`, `permissions()`, `oauthProviders()`, `smsTemplates()`, `phoneNumbers()`, `externalAccounts()`, `passkeys()`.
+Resource managers: `users()`, `sessions()`, `invitations()`, `allowlistIdentifiers()`, `blocklistIdentifiers()`, `redirectUrls()`, `instance()`, `webhookEndpoints()`, `organizations()`, `roles()`, `permissions()`, `oauthProviders()`, `smsTemplates()`, `phoneNumbers()`, `externalAccounts()`, `passkeys()`, `appearance()`, `localization()`.
 
 Organization sub-managers are accessed via `$client->organizations()`:
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,10 +6,12 @@ namespace Authn\Sdk;
 
 use Authn\Sdk\Http\Transport;
 use Authn\Sdk\Resources\AllowlistIdentifiersManager;
+use Authn\Sdk\Resources\AppearanceManager;
 use Authn\Sdk\Resources\BlocklistIdentifiersManager;
 use Authn\Sdk\Resources\ExternalAccountsManager;
 use Authn\Sdk\Resources\InstanceManager;
 use Authn\Sdk\Resources\InvitationsManager;
+use Authn\Sdk\Resources\LocalizationManager;
 use Authn\Sdk\Resources\OauthProvidersManager;
 use Authn\Sdk\Resources\OrganizationsManager;
 use Authn\Sdk\Resources\PasskeysManager;
@@ -134,5 +136,15 @@ final class Client
     public function passkeys(): PasskeysManager
     {
         return new PasskeysManager($this->transport);
+    }
+
+    public function appearance(): AppearanceManager
+    {
+        return new AppearanceManager($this->transport);
+    }
+
+    public function localization(): LocalizationManager
+    {
+        return new LocalizationManager($this->transport);
     }
 }

--- a/src/Resources/Appearance.php
+++ b/src/Resources/Appearance.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class Appearance
+{
+    /**
+     * @param  array<string, string>  $variables
+     * @param  array<string, string>  $elements
+     * @param  array<string, mixed>  $layout
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly array $variables = [],
+        public readonly array $elements = [],
+        public readonly array $layout = [],
+        public readonly array $raw = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            variables: self::stringMap($payload['variables'] ?? []),
+            elements: self::stringMap($payload['elements'] ?? []),
+            layout: self::mixedMap($payload['layout'] ?? []),
+            raw: $payload,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPayload(): array
+    {
+        $out = [];
+        if ($this->variables !== []) {
+            $out['variables'] = $this->variables;
+        }
+        if ($this->elements !== []) {
+            $out['elements'] = $this->elements;
+        }
+        if ($this->layout !== []) {
+            $out['layout'] = $this->layout;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function stringMap(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $k => $v) {
+            if (is_string($k) && is_string($v)) {
+                $out[$k] = $v;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function mixedMap(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $k => $v) {
+            if (is_string($k)) {
+                $out[$k] = $v;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Resources/AppearanceManager.php
+++ b/src/Resources/AppearanceManager.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class AppearanceManager extends Manager
+{
+    public function get(): Appearance
+    {
+        $payload = $this->transport->send('GET', '/v1/instance/appearance');
+
+        return Appearance::fromPayload($payload);
+    }
+
+    public function put(Appearance $appearance, ?string $idempotencyKey = null): Appearance
+    {
+        $payload = $this->transport->send('PUT', '/v1/instance/appearance', [
+            'body' => $appearance->toPayload(),
+            'idempotencyKey' => $idempotencyKey,
+        ]);
+
+        return Appearance::fromPayload($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $partial
+     */
+    public function patch(array $partial, ?string $idempotencyKey = null): Appearance
+    {
+        $payload = $this->transport->send('PATCH', '/v1/instance/appearance', [
+            'body' => $partial,
+            'idempotencyKey' => $idempotencyKey,
+        ]);
+
+        return Appearance::fromPayload($payload);
+    }
+}

--- a/src/Resources/Localization.php
+++ b/src/Resources/Localization.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class Localization
+{
+    /**
+     * @param  list<string>  $supportedLocales
+     * @param  array<string, array<string, string>>  $overrides
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $defaultLocale,
+        public readonly string $fallbackLocale,
+        public readonly array $supportedLocales,
+        public readonly array $overrides,
+        public readonly array $raw = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            defaultLocale: self::stringField($payload, 'default_locale'),
+            fallbackLocale: self::stringField($payload, 'fallback_locale'),
+            supportedLocales: self::stringList($payload['supported_locales'] ?? []),
+            overrides: self::overridesMap($payload['overrides'] ?? []),
+            raw: $payload,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPayload(): array
+    {
+        return [
+            'default_locale' => $this->defaultLocale,
+            'fallback_locale' => $this->fallbackLocale,
+            'supported_locales' => $this->supportedLocales,
+            'overrides' => $this->overrides === [] ? new \stdClass : $this->overrides,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function stringField(array $payload, string $key): string
+    {
+        $value = $payload[$key] ?? null;
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $out[] = $item;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private static function overridesMap(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $locale => $catalog) {
+            if (! is_string($locale) || ! is_array($catalog)) {
+                continue;
+            }
+            $entry = [];
+            foreach ($catalog as $key => $translation) {
+                if (is_string($key) && is_string($translation)) {
+                    $entry[$key] = $translation;
+                }
+            }
+            $out[$locale] = $entry;
+        }
+
+        return $out;
+    }
+}

--- a/src/Resources/LocalizationManager.php
+++ b/src/Resources/LocalizationManager.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class LocalizationManager extends Manager
+{
+    public function get(): Localization
+    {
+        $payload = $this->transport->send('GET', '/v1/instance/localization');
+
+        return Localization::fromPayload($payload);
+    }
+
+    public function put(Localization $localization, ?string $idempotencyKey = null): Localization
+    {
+        $payload = $this->transport->send('PUT', '/v1/instance/localization', [
+            'body' => $localization->toPayload(),
+            'idempotencyKey' => $idempotencyKey,
+        ]);
+
+        return Localization::fromPayload($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $partial
+     */
+    public function patch(array $partial, ?string $idempotencyKey = null): Localization
+    {
+        $payload = $this->transport->send('PATCH', '/v1/instance/localization', [
+            'body' => $partial,
+            'idempotencyKey' => $idempotencyKey,
+        ]);
+
+        return Localization::fromPayload($payload);
+    }
+}

--- a/tests/Resources/AppearanceManagerTest.php
+++ b/tests/Resources/AppearanceManagerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Resources\Appearance;
+use Authn\Sdk\Resources\AppearanceManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+/**
+ * @return array<string, mixed>
+ */
+function fullAppearancePayload(): array
+{
+    return [
+        'variables' => [
+            'colorPrimary' => '#0a84ff',
+            'colorTextOnPrimary' => '#ffffff',
+            'borderRadius' => '0.5rem',
+        ],
+        'elements' => [
+            'card' => 'shadow-2xl border border-slate-700',
+            'formButtonPrimary' => 'tracking-wide uppercase',
+        ],
+        'layout' => [
+            'logoImageUrl' => 'https://cdn.acme.com/logo-dark.svg',
+            'socialButtonsPlacement' => 'top',
+            'animations' => true,
+            'showOptionalFields' => false,
+        ],
+    ];
+}
+
+it('gets the appearance config (defaults — empty payload)', function (): void {
+    $mock = (new MockTransport)->enqueue(body: []);
+    $manager = new AppearanceManager($mock->transport());
+
+    $appearance = $manager->get();
+
+    expect($appearance)->toBeInstanceOf(Appearance::class);
+    expect($appearance->variables)->toBe([]);
+    expect($appearance->elements)->toBe([]);
+    expect($appearance->layout)->toBe([]);
+    expect($mock->lastRequest()->getMethod())->toBe('GET');
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/instance/appearance');
+});
+
+it('parses a fully-populated appearance payload', function (): void {
+    $mock = (new MockTransport)->enqueue(body: fullAppearancePayload());
+    $manager = new AppearanceManager($mock->transport());
+
+    $appearance = $manager->get();
+
+    expect($appearance->variables)->toMatchArray(['colorPrimary' => '#0a84ff']);
+    expect($appearance->elements)->toMatchArray(['card' => 'shadow-2xl border border-slate-700']);
+    expect($appearance->layout)->toMatchArray([
+        'logoImageUrl' => 'https://cdn.acme.com/logo-dark.svg',
+        'animations' => true,
+        'showOptionalFields' => false,
+    ]);
+});
+
+it('PUT replaces the appearance with a serialized payload', function (): void {
+    $mock = (new MockTransport)->enqueue(body: fullAppearancePayload());
+    $manager = new AppearanceManager($mock->transport());
+
+    $next = new Appearance(
+        variables: ['colorPrimary' => '#0a84ff', 'colorTextOnPrimary' => '#ffffff', 'borderRadius' => '0.5rem'],
+        elements: ['card' => 'shadow-2xl border border-slate-700', 'formButtonPrimary' => 'tracking-wide uppercase'],
+        layout: ['logoImageUrl' => 'https://cdn.acme.com/logo-dark.svg', 'socialButtonsPlacement' => 'top', 'animations' => true, 'showOptionalFields' => false],
+    );
+
+    $result = $manager->put($next, idempotencyKey: 'idem-put');
+
+    expect($result)->toBeInstanceOf(Appearance::class);
+    expect($mock->lastRequest()->getMethod())->toBe('PUT');
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->toBe('idem-put');
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/instance/appearance');
+    /** @var array<string, array<string, mixed>> $body */
+    $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+    expect($body)->toHaveKeys(['variables', 'elements', 'layout']);
+    expect($body['variables'])->toMatchArray(['colorPrimary' => '#0a84ff']);
+});
+
+it('PATCH sends only the supplied keys (sparse deep-merge)', function (): void {
+    $mock = (new MockTransport)->enqueue(body: fullAppearancePayload());
+    $manager = new AppearanceManager($mock->transport());
+
+    $manager->patch(['variables' => ['colorPrimary' => '#16a34a', 'colorTextOnPrimary' => '#ffffff']]);
+
+    expect($mock->lastRequest()->getMethod())->toBe('PATCH');
+    $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+    expect($body)->toBe([
+        'variables' => ['colorPrimary' => '#16a34a', 'colorTextOnPrimary' => '#ffffff'],
+    ]);
+});
+
+it('PUT an empty Appearance sends an empty body', function (): void {
+    $mock = (new MockTransport)->enqueue(body: []);
+    $manager = new AppearanceManager($mock->transport());
+
+    $manager->put(new Appearance);
+
+    $body = (string) $mock->lastRequest()->getBody();
+    expect($body)->toBeIn(['{}', '[]']);
+});
+
+it('surfaces 422 from PUT as ApiException', function (): void {
+    $mock = (new MockTransport)->enqueue(422, [
+        'errors' => [['code' => 'invalid_variable', 'message' => 'bad token', 'long_message' => '...']],
+    ]);
+    $manager = new AppearanceManager($mock->transport());
+
+    expect(fn () => $manager->put(new Appearance(variables: ['colorPrimary' => 'nope'])))
+        ->toThrow(ApiException::class);
+});
+
+it('Client::appearance() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: []);
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->appearance())->toBeInstanceOf(AppearanceManager::class);
+});

--- a/tests/Resources/LocalizationManagerTest.php
+++ b/tests/Resources/LocalizationManagerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Resources\Localization;
+use Authn\Sdk\Resources\LocalizationManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+/**
+ * @return array<string, mixed>
+ */
+function defaultsOnlyLocalizationPayload(): array
+{
+    return [
+        'default_locale' => 'en-US',
+        'fallback_locale' => 'en-US',
+        'supported_locales' => ['en-US', 'pt-BR', 'es-ES', 'fr-FR', 'de-DE'],
+        'overrides' => [],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function ptBROverrideLocalizationPayload(): array
+{
+    return [
+        'default_locale' => 'pt-BR',
+        'fallback_locale' => 'en-US',
+        'supported_locales' => ['en-US', 'pt-BR'],
+        'overrides' => [
+            'pt-BR' => [
+                'signIn.start.title' => 'Bem-vindo de volta',
+                'signIn.start.actionText' => 'Não tem uma conta?',
+            ],
+        ],
+    ];
+}
+
+it('gets the localization config with defaults only', function (): void {
+    $mock = (new MockTransport)->enqueue(body: defaultsOnlyLocalizationPayload());
+    $manager = new LocalizationManager($mock->transport());
+
+    $loc = $manager->get();
+
+    expect($loc)->toBeInstanceOf(Localization::class);
+    expect($loc->defaultLocale)->toBe('en-US');
+    expect($loc->fallbackLocale)->toBe('en-US');
+    expect($loc->supportedLocales)->toBe(['en-US', 'pt-BR', 'es-ES', 'fr-FR', 'de-DE']);
+    expect($loc->overrides)->toBe([]);
+    expect((string) $mock->lastRequest()->getUri())->toEndWith('/v1/instance/localization');
+});
+
+it('parses per-locale overrides', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ptBROverrideLocalizationPayload());
+    $manager = new LocalizationManager($mock->transport());
+
+    $loc = $manager->get();
+
+    expect($loc->overrides)->toHaveKey('pt-BR');
+    expect($loc->overrides['pt-BR'])->toMatchArray([
+        'signIn.start.title' => 'Bem-vindo de volta',
+    ]);
+});
+
+it('PUT replaces the localization with a serialized payload', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ptBROverrideLocalizationPayload());
+    $manager = new LocalizationManager($mock->transport());
+
+    $next = new Localization(
+        defaultLocale: 'pt-BR',
+        fallbackLocale: 'en-US',
+        supportedLocales: ['en-US', 'pt-BR'],
+        overrides: ['pt-BR' => ['signIn.start.title' => 'Bem-vindo de volta']],
+    );
+
+    $manager->put($next, idempotencyKey: 'idem-put');
+
+    expect($mock->lastRequest()->getMethod())->toBe('PUT');
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->toBe('idem-put');
+    $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+    expect($body)->toBe([
+        'default_locale' => 'pt-BR',
+        'fallback_locale' => 'en-US',
+        'supported_locales' => ['en-US', 'pt-BR'],
+        'overrides' => ['pt-BR' => ['signIn.start.title' => 'Bem-vindo de volta']],
+    ]);
+});
+
+it('PATCH adds a single override (sparse merge)', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ptBROverrideLocalizationPayload());
+    $manager = new LocalizationManager($mock->transport());
+
+    $manager->patch([
+        'overrides' => [
+            'pt-BR' => ['signIn.start.title' => 'Bem-vindo de volta'],
+        ],
+    ]);
+
+    expect($mock->lastRequest()->getMethod())->toBe('PATCH');
+    $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+    expect($body)->toBe([
+        'overrides' => [
+            'pt-BR' => ['signIn.start.title' => 'Bem-vindo de volta'],
+        ],
+    ]);
+});
+
+it('PATCH with explicit null on a key clears that override', function (): void {
+    $mock = (new MockTransport)->enqueue(body: defaultsOnlyLocalizationPayload());
+    $manager = new LocalizationManager($mock->transport());
+
+    $manager->patch([
+        'overrides' => [
+            'pt-BR' => ['signIn.start.title' => null],
+        ],
+    ]);
+
+    $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+    expect($body)->toBe([
+        'overrides' => [
+            'pt-BR' => ['signIn.start.title' => null],
+        ],
+    ]);
+});
+
+it('PATCH can change the default_locale alone', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ptBROverrideLocalizationPayload());
+    $manager = new LocalizationManager($mock->transport());
+
+    $manager->patch(['default_locale' => 'pt-BR']);
+
+    $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+    expect($body)->toBe(['default_locale' => 'pt-BR']);
+});
+
+it('surfaces 422 unknown_localization_key as ApiException', function (): void {
+    $mock = (new MockTransport)->enqueue(422, [
+        'errors' => [['code' => 'unknown_localization_key', 'message' => 'unknown', 'long_message' => '...']],
+    ]);
+    $manager = new LocalizationManager($mock->transport());
+
+    expect(fn () => $manager->patch(['overrides' => ['en-US' => ['nonsense.key' => 'x']]]))
+        ->toThrow(ApiException::class);
+});
+
+it('Client::localization() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: defaultsOnlyLocalizationPayload());
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->localization())->toBeInstanceOf(LocalizationManager::class);
+});


### PR DESCRIPTION
## Summary

Adds the two admin-side instance-config managers for v0.5:

- `AppearanceManager` (`get`, `put`, `patch`) wrapping `/v1/instance/appearance`. `PUT` is a full replace; `PATCH` is a deep merge across `variables` / `elements` / `layout`.
- `LocalizationManager` (`get`, `put`, `patch`) wrapping `/v1/instance/localization`. `PATCH` supports the sparse per-key override merge — passing `null` for a key under `overrides[locale]` removes that single override (the SDK falls back to the canonical catalog).

DTOs `Appearance` (variables / elements / layout) and `Localization` (default_locale, fallback_locale, supported_locales, overrides) mirror OA-4 and OA-5. Empty `Appearance` blocks are omitted from the serialized body so an untouched section never overwrites the operator's stored config. An empty `Localization.overrides` map is serialized as a JSON object (not an array) so the validator accepts it.

## Test plan

- [x] `composer test` — 166 passed (15 new tests, 482 assertions)
- [x] `composer phpstan` — clean
- [x] `composer pint` — clean

Test coverage:
- Appearance: empty-defaults GET, fully-populated GET parsing, `PUT` round-trip with idempotency key + body shape, sparse `PATCH` body, empty `PUT` body shape, 422 surfacing as `ApiException`, `Client::appearance()` wiring.
- Localization: defaults-only GET, per-locale overrides GET, `PUT` round-trip body shape, sparse `PATCH` adds-a-single-key, `PATCH` with explicit `null` to remove, `PATCH default_locale` alone, 422 `unknown_localization_key` surfacing, `Client::localization()` wiring.

Closes #34