### PR TITLE
SP-3: TokenVerifier surfaces passkey claims (pkv / pkc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `PasskeysManager` — BAPI binding for `/v1/passkeys` (`list`, `get`, `update(id, nickname)`, `delete`) plus the `Passkey` DTO and `PasskeysListParams` (with `user_id` filter). Accessible via `$client->passkeys()`. Enrollment is FAPI-only (browser ceremony) and is not surfaced here.
 - `AppearanceManager` — BAPI binding for `/v1/instance/appearance` (`get`, `put`, `patch`) plus the `Appearance` DTO (`variables`, `elements`, `layout`). Accessible via `$client->appearance()`. `patch()` accepts a sparse array; the server deep-merges supplied keys.
 - `LocalizationManager` — BAPI binding for `/v1/instance/localization` (`get`, `put`, `patch`) plus the `Localization` DTO (`default_locale`, `fallback_locale`, `supported_locales[]`, `overrides`). Accessible via `$client->localization()`. `patch()` supports the sparse per-key override merge: passing `null` for a key under `overrides[locale]` removes that single override.
+- `VerifiedClaims->passkeyVerified: bool` parsed from the `pkv` JWT claim. `true` when the current session was authenticated by a passkey first-factor Challenge with `userVerification = required`. Defaults to `false` when the claim is absent.
+- `VerifiedClaims->passkeyCount: int` parsed from the `pkc` JWT claim. Snapshot of the user's verified-passkey count at session creation. Defaults to `0` when the claim is absent or not a non-negative integer.
+- `VerifiedClaims::wasVerifiedByPasskey()` and `::hasPasskey()` helper methods.
 
 ## [0.4.0] — 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ $claims->hasRole('org:admin');
 $claims->hasPermission(SystemPermissions::ORG_SYS_PROFILE_MANAGE);
 ```
 
+### Passkey claims
+
+`$claims->passkeyVerified` is `true` when the current session was authenticated by a passkey first-factor with `userVerification = required` (parsed from the `pkv` JWT claim). `$claims->passkeyCount` is the snapshot of the user's verified-passkey count at session creation (`pkc` claim).
+
+```php
+$claims = $verifier->verify($jwt);
+
+// Gate sensitive operations to passkey-authenticated sessions.
+if (! $claims->wasVerifiedByPasskey()) {
+    abort(403, 'Sensitive operation requires a passkey session.');
+}
+
+// Nudge a user who has zero passkeys towards enrollment.
+if (! $claims->hasPasskey()) {
+    // render passkey-enrollment CTA
+}
+```
+
 ## Verify a webhook
 
 ```php

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -265,6 +265,11 @@ final class TokenVerifier
         $phoneNumberVerified = isset($claims['pnv']) && $claims['pnv'] === true;
         $defaultSecondFactor = $this->parseDefaultSecondFactor($claims);
 
+        $passkeyVerified = isset($claims['pkv']) && $claims['pkv'] === true;
+        $passkeyCount = isset($claims['pkc']) && is_int($claims['pkc']) && $claims['pkc'] >= 0
+            ? $claims['pkc']
+            : 0;
+
         return new VerifiedClaims(
             sub: $sub,
             sid: $sid,
@@ -283,6 +288,8 @@ final class TokenVerifier
             firstFactorAgeSeconds: $firstFactorAgeSeconds,
             phoneNumberVerified: $phoneNumberVerified,
             defaultSecondFactor: $defaultSecondFactor,
+            passkeyVerified: $passkeyVerified,
+            passkeyCount: $passkeyCount,
         );
     }
 

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -35,6 +35,8 @@ final class VerifiedClaims
         public readonly ?int $firstFactorAgeSeconds = null,
         public readonly bool $phoneNumberVerified = false,
         public readonly ?string $defaultSecondFactor = null,
+        public readonly bool $passkeyVerified = false,
+        public readonly int $passkeyCount = 0,
     ) {}
 
     public function hasRole(string $key): bool
@@ -55,5 +57,15 @@ final class VerifiedClaims
     public function preferredSecondFactor(): ?string
     {
         return $this->defaultSecondFactor;
+    }
+
+    public function wasVerifiedByPasskey(): bool
+    {
+        return $this->passkeyVerified;
+    }
+
+    public function hasPasskey(): bool
+    {
+        return $this->passkeyCount > 0;
     }
 }

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -364,3 +364,81 @@ it('rejects unknown dsf values as null defaultSecondFactor', function (): void {
 
     expect($verified->defaultSecondFactor)->toBeNull();
 });
+
+it('surfaces passkeyVerified=true when pkv claim is true', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['pkv'] = true;
+    $claims['pkc'] = 2;
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->passkeyVerified)->toBeTrue();
+    expect($verified->wasVerifiedByPasskey())->toBeTrue();
+    expect($verified->passkeyCount)->toBe(2);
+    expect($verified->hasPasskey())->toBeTrue();
+});
+
+it('defaults passkey claims when pkv and pkc are absent (non-passkey session)', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->passkeyVerified)->toBeFalse();
+    expect($verified->wasVerifiedByPasskey())->toBeFalse();
+    expect($verified->passkeyCount)->toBe(0);
+    expect($verified->hasPasskey())->toBeFalse();
+});
+
+it('treats pkv: false as passkeyVerified=false', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['pkv'] = false;
+    $claims['pkc'] = 0;
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->passkeyVerified)->toBeFalse();
+    expect($verified->passkeyCount)->toBe(0);
+    expect($verified->hasPasskey())->toBeFalse();
+});
+
+it('exposes both passkeyVerified and twoFactorVerified for passkey + TOTP step-up sessions', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['pkv'] = true;
+    $claims['pkc'] = 1;
+    $claims['fva'] = [30, 120];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->passkeyVerified)->toBeTrue();
+    expect($verified->twoFactorVerified)->toBeTrue();
+    expect($verified->firstFactorAgeSeconds)->toBe(30);
+    expect($verified->secondFactorAgeSeconds)->toBe(120);
+});
+
+it('ignores non-integer and negative pkc values, defaulting passkeyCount to 0', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['pkc'] = '3';
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->passkeyCount)->toBe(0);
+
+    $claims2 = validClaims();
+    $claims2['pkc'] = -1;
+    $verified2 = $verifier->verify($fixture->sign($claims2));
+
+    expect($verified2->passkeyCount)->toBe(0);
+});


### PR DESCRIPTION
## Summary

\`VerifiedClaims\` now exposes two passkey-related fields parsed by \`TokenVerifier\` from session JWTs:

- \`passkeyVerified: bool\` — parsed from the \`pkv\` claim. \`true\` when the session was authenticated by a passkey first-factor Challenge with \`userVerification = required\`. Defaults to \`false\` when absent.
- \`passkeyCount: int\` — parsed from the \`pkc\` claim. Snapshot of the user's verified-passkey count at session creation. Defaults to \`0\` when absent or not a non-negative integer.

Adds \`wasVerifiedByPasskey()\` and \`hasPasskey()\` convenience methods mirroring the v0.4 \`phoneNumberVerified\` / \`defaultSecondFactor\` plumbing.

## Note on claim emission

The SDK is now ready to consume \`pkv\` / \`pkc\` in the compact JWT-claim convention (alongside \`pnv\`, \`dsf\`, \`fva\`). Honouring both claims server-side is bundled into the AU-12 audit/webhook work (authn-sh/authn#173) — the SDK fields default safely on legacy tokens that pre-date that emission, so this PR can ship before AU-12 lands.

## Test plan

- [x] \`composer test\` — 171 passed (5 new, 499 assertions)
- [x] \`composer phpstan\` — clean
- [x] \`composer pint\` — clean

Test coverage:
- Passkey-verified session with \`pkc > 0\` populates both fields and helpers.
- Both claims absent → defaults (\`false\` / \`0\`); helpers return \`false\`.
- \`pkv: false\` parsed as \`passkeyVerified = false\`.
- Passkey + TOTP step-up exposes both \`passkeyVerified\` and \`twoFactorVerified\` plus the existing \`fva\` ages.
- Non-integer (\`"3"\`) and negative (\`-1\`) \`pkc\` parsed as \`0\`.

Closes #35