### PR TITLE
Cut v0.5.0: rename Unreleased to [0.5.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.5.0] — 2026-05-11
 
 ### Added
 


### PR DESCRIPTION
Step 3 of the v0.5.0 cross-repo release dance. Renames the existing `Unreleased` CHANGELOG section to `[0.5.0] — 2026-05-11`. No code changes.