### PR TITLE
SP-3: TokenVerifier surfaces entcon + entacc claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - `EnterpriseConnectionsManager` — BAPI binding for `/v1/enterprise-connections` (`list`, `create`, `get`, `update`, `delete`, `test`) plus the `EnterpriseConnection` DTO (carrying both SAML and OIDC fields, discriminated by `protocol`), `EnterpriseConnectionTestResult` + `EnterpriseConnectionTestError`, and `EnterpriseConnectionsListParams` (with the `organization_id` filter — pass an `Organization.id` for org-scoped rows, the literal `"null"` for instance-wide only, or omit for both). Accessible via `$client->enterpriseConnections()`. Write-only secrets (`oidc_client_secret`, `saml_signing_key`) are accepted on `create`/`update` and never returned on read.
 - `EnterpriseAccount` DTO — read-only shape for the per-user link to an `EnterpriseConnection`. Carries `provider_user_id`, `email_address`, `verified`, `public_metadata` (raw IdP attributes that did not map to a `User` field), `linked_at`, and `last_signed_in_at`. Exposed by the embedded `enterprise_accounts[]` array on `User`. The BAPI does not expose a top-level `/v1/enterprise-accounts` surface in v0.6 — enterprise accounts are managed by deleting the parent `EnterpriseConnection` or by removing the user.
+- `VerifiedClaims->enterpriseConnectionId: ?string` parsed from the `entcon` JWT claim — `EnterpriseConnection.id` of the IdP that minted the session. `null` when the session was authenticated by any non-enterprise strategy (password, oauth, passkey, etc.).
+- `VerifiedClaims->enterpriseAccountId: ?string` parsed from the `entacc` JWT claim — `EnterpriseAccount.id` linking the user to that connection. `null` for non-enterprise sessions.
+- `VerifiedClaims::wasVerifiedByEnterpriseSso()` helper. Returns `true` when `enterpriseConnectionId !== null` — the cheapest test for "this session went through SAML / OIDC enterprise SSO".
 
 ## [0.5.0] — 2026-05-11
 

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -270,6 +270,13 @@ final class TokenVerifier
             ? $claims['pkc']
             : 0;
 
+        $enterpriseConnectionId = isset($claims['entcon']) && is_string($claims['entcon']) && $claims['entcon'] !== ''
+            ? $claims['entcon']
+            : null;
+        $enterpriseAccountId = isset($claims['entacc']) && is_string($claims['entacc']) && $claims['entacc'] !== ''
+            ? $claims['entacc']
+            : null;
+
         return new VerifiedClaims(
             sub: $sub,
             sid: $sid,
@@ -290,6 +297,8 @@ final class TokenVerifier
             defaultSecondFactor: $defaultSecondFactor,
             passkeyVerified: $passkeyVerified,
             passkeyCount: $passkeyCount,
+            enterpriseConnectionId: $enterpriseConnectionId,
+            enterpriseAccountId: $enterpriseAccountId,
         );
     }
 

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -37,6 +37,8 @@ final class VerifiedClaims
         public readonly ?string $defaultSecondFactor = null,
         public readonly bool $passkeyVerified = false,
         public readonly int $passkeyCount = 0,
+        public readonly ?string $enterpriseConnectionId = null,
+        public readonly ?string $enterpriseAccountId = null,
     ) {}
 
     public function hasRole(string $key): bool
@@ -67,5 +69,10 @@ final class VerifiedClaims
     public function hasPasskey(): bool
     {
         return $this->passkeyCount > 0;
+    }
+
+    public function wasVerifiedByEnterpriseSso(): bool
+    {
+        return $this->enterpriseConnectionId !== null;
     }
 }

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -442,3 +442,79 @@ it('ignores non-integer and negative pkc values, defaulting passkeyCount to 0', 
 
     expect($verified2->passkeyCount)->toBe(0);
 });
+
+it('surfaces enterprise SSO claims when entcon and entacc are present', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['entcon'] = 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA';
+    $claims['entacc'] = 'entacc_01HKX9SY9V7H7TF8C8K7J9X4ZB';
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->enterpriseConnectionId)->toBe('entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+    expect($verified->enterpriseAccountId)->toBe('entacc_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+    expect($verified->wasVerifiedByEnterpriseSso())->toBeTrue();
+});
+
+it('defaults entcon and entacc to null on a non-enterprise session', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->enterpriseConnectionId)->toBeNull();
+    expect($verified->enterpriseAccountId)->toBeNull();
+    expect($verified->wasVerifiedByEnterpriseSso())->toBeFalse();
+});
+
+it('ignores non-string entcon and entacc values, defaulting to null', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['entcon'] = 123;
+    $claims['entacc'] = ['nested' => 'value'];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->enterpriseConnectionId)->toBeNull();
+    expect($verified->enterpriseAccountId)->toBeNull();
+    expect($verified->wasVerifiedByEnterpriseSso())->toBeFalse();
+});
+
+it('treats empty-string entcon and entacc as absent', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['entcon'] = '';
+    $claims['entacc'] = '';
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->enterpriseConnectionId)->toBeNull();
+    expect($verified->enterpriseAccountId)->toBeNull();
+    expect($verified->wasVerifiedByEnterpriseSso())->toBeFalse();
+});
+
+it('preserves entcon and entacc across impersonation (actor) sessions', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['entcon'] = 'entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA';
+    $claims['entacc'] = 'entacc_01HKX9SY9V7H7TF8C8K7J9X4ZB';
+    $claims['act'] = [
+        'iss' => $claims['iss'],
+        'sub' => 'user_admin',
+        'sid' => 'sess_admin',
+    ];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->actor)->not->toBeNull();
+    expect($verified->enterpriseConnectionId)->toBe('entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+    expect($verified->enterpriseAccountId)->toBe('entacc_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+});


### PR DESCRIPTION
Closes #42

## Summary

`TokenVerifier` now parses the `entcon` and `entacc` claims emitted by AU-16 (authn-sh/authn#207) and exposes them on `VerifiedClaims`:

- `VerifiedClaims->enterpriseConnectionId: ?string` — `EnterpriseConnection.id` of the IdP that authenticated the session (prefix `entcon_`). `null` when the session was minted from any non-enterprise strategy.
- `VerifiedClaims->enterpriseAccountId: ?string` — `EnterpriseAccount.id` linking the user to that connection (prefix `entacc_`). `null` for non-enterprise sessions.
- `VerifiedClaims::wasVerifiedByEnterpriseSso(): bool` — convenience helper returning `true` iff `enterpriseConnectionId !== null`.

The parsing mirrors the v0.5 `pkv` / `pkc` pattern in `buildVerifiedClaims()`: ignore non-string values, ignore empty strings, default to `null`. No new dependencies, no changes to verify-success / verify-failure semantics.

## Test plan

- [x] `composer pint` — clean
- [x] `composer phpstan` — no errors
- [x] `composer test` — 191 passed (567 assertions). New cases in `tests/Tokens/TokenVerifierTest.php`:
  - both `entcon` + `entacc` set populate both fields and the helper returns `true`
  - absent claims → both `null`, helper returns `false`
  - non-string `entcon` (int) and `entacc` (array) → ignored, both `null`
  - empty-string claims → treated as absent
  - impersonation (`act` claim) sessions preserve both fields