### PR TITLE
Cut v0.6.0: rename Unreleased to [0.6.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] — 2026-05-12
 
 ### Added
 


### PR DESCRIPTION
Step 3 of the v0.6.0 cross-repo release dance.