### PR TITLE
SP-2: BAPI ScimTokensManager + ScimAttributeMappingsManager (v0.6 carryover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `ScimTokensManager` — BAPI binding for `/v1/organizations/{org_id}/scim/tokens` (`list`, `issue(name)`, `revoke(id)`) plus the `ScimToken` DTO (`id`, `organizationId`, `name`, `prefix`, `createdAt`, `revokedAt`) and `ScimTokenWithPlaintext` (issue-response only — carries the full `token` plaintext exactly once). Accessible via `$client->organizations()->scimTokens($orgId)`.
+- `ScimAttributeMappingsManager` — BAPI binding for `/v1/organizations/{org_id}/scim/attribute-mappings` (`get`, `put(mapping)`) and `/v1/organizations/{org_id}/scim/endpoint` (`endpoint()`). Plus the `ScimAttributeMapping` DTO. Accessible via `$client->organizations()->scimAttributeMappings($orgId)`. `put()` is a full-resource replace — unsupplied keys revert to server defaults.
+
 ## [0.6.0] — 2026-05-12
 
 ### Added

--- a/src/Resources/OrganizationsManager.php
+++ b/src/Resources/OrganizationsManager.php
@@ -68,4 +68,14 @@ final class OrganizationsManager extends Manager
     {
         return new OrganizationDomainsManager($this->transport, $orgId);
     }
+
+    public function scimTokens(string $orgId): ScimTokensManager
+    {
+        return new ScimTokensManager($this->transport, $orgId);
+    }
+
+    public function scimAttributeMappings(string $orgId): ScimAttributeMappingsManager
+    {
+        return new ScimAttributeMappingsManager($this->transport, $orgId);
+    }
 }

--- a/src/Resources/ScimAttributeMapping.php
+++ b/src/Resources/ScimAttributeMapping.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class ScimAttributeMapping
+{
+    /**
+     * @param  array<string, string>  $mapping
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $organizationId,
+        public readonly array $mapping,
+        public readonly array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        $organizationId = $payload['organization_id'] ?? null;
+        $mapping = [];
+        if (isset($payload['mapping']) && is_array($payload['mapping'])) {
+            foreach ($payload['mapping'] as $key => $value) {
+                if (is_string($key) && is_string($value)) {
+                    $mapping[$key] = $value;
+                }
+            }
+        }
+
+        return new self(
+            organizationId: is_string($organizationId) ? $organizationId : '',
+            mapping: $mapping,
+            raw: $payload,
+        );
+    }
+}

--- a/src/Resources/ScimAttributeMappingsManager.php
+++ b/src/Resources/ScimAttributeMappingsManager.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+use Authn\Sdk\Http\Transport;
+
+final class ScimAttributeMappingsManager extends Manager
+{
+    public function __construct(Transport $transport, private readonly string $orgId)
+    {
+        parent::__construct($transport);
+    }
+
+    public function get(): ScimAttributeMapping
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/organizations/' . rawurlencode($this->orgId) . '/scim/attribute-mappings',
+        );
+
+        return ScimAttributeMapping::fromPayload($payload);
+    }
+
+    /**
+     * @param  array<string, string>  $mapping
+     */
+    public function put(array $mapping): ScimAttributeMapping
+    {
+        $payload = $this->transport->send(
+            'PUT',
+            '/v1/organizations/' . rawurlencode($this->orgId) . '/scim/attribute-mappings',
+            ['body' => ['mapping' => $mapping]],
+        );
+
+        return ScimAttributeMapping::fromPayload($payload);
+    }
+
+    /**
+     * @return array{endpoint_url: string}
+     */
+    public function endpoint(): array
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/organizations/' . rawurlencode($this->orgId) . '/scim/endpoint',
+        );
+
+        $url = isset($payload['endpoint_url']) && is_string($payload['endpoint_url']) ? $payload['endpoint_url'] : '';
+
+        return ['endpoint_url' => $url];
+    }
+}

--- a/src/Resources/ScimToken.php
+++ b/src/Resources/ScimToken.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+class ScimToken
+{
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $organizationId,
+        public readonly string $name,
+        public readonly string $prefix,
+        public readonly int $createdAt,
+        public readonly ?int $revokedAt,
+        public readonly array $raw,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self(
+            id: self::stringField($payload, 'id'),
+            organizationId: self::stringField($payload, 'organization_id'),
+            name: self::stringField($payload, 'name'),
+            prefix: self::stringField($payload, 'prefix'),
+            createdAt: self::intField($payload, 'created_at'),
+            revokedAt: isset($payload['revoked_at']) && is_int($payload['revoked_at']) ? $payload['revoked_at'] : null,
+            raw: $payload,
+        );
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revokedAt !== null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected static function stringField(array $payload, string $key): string
+    {
+        $value = $payload[$key] ?? null;
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected static function intField(array $payload, string $key): int
+    {
+        $value = $payload[$key] ?? null;
+
+        return is_int($value) ? $value : 0;
+    }
+}

--- a/src/Resources/ScimTokenWithPlaintext.php
+++ b/src/Resources/ScimTokenWithPlaintext.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+final class ScimTokenWithPlaintext extends ScimToken
+{
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        string $id,
+        string $organizationId,
+        string $name,
+        string $prefix,
+        int $createdAt,
+        ?int $revokedAt,
+        array $raw,
+        public readonly string $token,
+    ) {
+        parent::__construct($id, $organizationId, $name, $prefix, $createdAt, $revokedAt, $raw);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        $token = $payload['token'] ?? null;
+        if (! is_string($token) || $token === '') {
+            throw new \RuntimeException('ScimTokenWithPlaintext requires a non-empty token field on the payload.');
+        }
+
+        return new self(
+            id: self::stringField($payload, 'id'),
+            organizationId: self::stringField($payload, 'organization_id'),
+            name: self::stringField($payload, 'name'),
+            prefix: self::stringField($payload, 'prefix'),
+            createdAt: self::intField($payload, 'created_at'),
+            revokedAt: isset($payload['revoked_at']) && is_int($payload['revoked_at']) ? $payload['revoked_at'] : null,
+            raw: $payload,
+            token: $token,
+        );
+    }
+}

--- a/src/Resources/ScimTokensManager.php
+++ b/src/Resources/ScimTokensManager.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Authn\Sdk\Resources;
+
+use Authn\Sdk\Http\Transport;
+use Authn\Sdk\Util\Idempotency;
+
+final class ScimTokensManager extends Manager
+{
+    public function __construct(Transport $transport, private readonly string $orgId)
+    {
+        parent::__construct($transport);
+    }
+
+    public function list(?ListParams $params = null): PaginatedList
+    {
+        $payload = $this->transport->send(
+            'GET',
+            '/v1/organizations/' . rawurlencode($this->orgId) . '/scim/tokens',
+            ['query' => ($params ?? new ListParams)->toQuery()],
+        );
+
+        return PaginatedList::fromResponse($payload);
+    }
+
+    public function issue(string $name, ?string $idempotencyKey = null): ScimTokenWithPlaintext
+    {
+        $data = ['name' => $name];
+
+        $payload = $this->transport->send(
+            'POST',
+            '/v1/organizations/' . rawurlencode($this->orgId) . '/scim/tokens',
+            [
+                'body' => $data,
+                'idempotencyKey' => $idempotencyKey ?? Idempotency::keyFor($data),
+            ],
+        );
+
+        return ScimTokenWithPlaintext::fromPayload($payload);
+    }
+
+    public function revoke(string $scimTokenId): ScimToken
+    {
+        $payload = $this->transport->send(
+            'POST',
+            '/v1/organizations/' . rawurlencode($this->orgId) . '/scim/tokens/' . rawurlencode($scimTokenId) . '/revoke',
+        );
+
+        return ScimToken::fromPayload($payload);
+    }
+}

--- a/tests/Resources/ScimAttributeMappingsManagerTest.php
+++ b/tests/Resources/ScimAttributeMappingsManagerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Resources\ScimAttributeMapping;
+use Authn\Sdk\Resources\ScimAttributeMappingsManager;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+/**
+ * @return array<string, mixed>
+ */
+function scimAttributeMappingPayload(): array
+{
+    return [
+        'organization_id' => 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'mapping' => [
+            'userName' => 'email_address',
+            'name.givenName' => 'first_name',
+            'name.familyName' => 'last_name',
+            'externalId' => 'external_id',
+        ],
+    ];
+}
+
+it('reads the SCIM attribute mapping for an organization', function (): void {
+    $mock = (new MockTransport)->enqueue(body: scimAttributeMappingPayload());
+    $manager = new ScimAttributeMappingsManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    $mapping = $manager->get();
+
+    expect($mapping)->toBeInstanceOf(ScimAttributeMapping::class);
+    expect($mapping->organizationId)->toBe('org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+    expect($mapping->mapping)->toBe([
+        'userName' => 'email_address',
+        'name.givenName' => 'first_name',
+        'name.familyName' => 'last_name',
+        'externalId' => 'external_id',
+    ]);
+    expect($mock->lastRequest()->getMethod())->toBe('GET');
+    expect((string) $mock->lastRequest()->getUri())
+        ->toEndWith('/v1/organizations/org_01HKX9SY9V7H7TF8C8K7J9X4ZB/scim/attribute-mappings');
+});
+
+it('replaces the SCIM attribute mapping via PUT', function (): void {
+    $payload = [
+        'organization_id' => 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'mapping' => [
+            'userName' => 'email_address',
+            'name.givenName' => 'first_name',
+            'name.familyName' => 'last_name',
+            'externalId' => 'external_id',
+            'urn:custom:department' => 'public_metadata.department',
+        ],
+    ];
+
+    $mock = (new MockTransport)->enqueue(body: $payload);
+    $manager = new ScimAttributeMappingsManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    $replaced = $manager->put([
+        'userName' => 'email_address',
+        'name.givenName' => 'first_name',
+        'name.familyName' => 'last_name',
+        'externalId' => 'external_id',
+        'urn:custom:department' => 'public_metadata.department',
+    ]);
+
+    expect($replaced->mapping)->toHaveKey('urn:custom:department');
+    expect($replaced->mapping['urn:custom:department'])->toBe('public_metadata.department');
+
+    expect($mock->lastRequest()->getMethod())->toBe('PUT');
+    expect((string) $mock->lastRequest()->getBody())->toContain('"mapping":{');
+});
+
+it('ignores non-string mapping entries in the response', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        'organization_id' => 'org_x',
+        'mapping' => [
+            'userName' => 'email_address',
+            'broken' => 42,
+            13 => 'numeric_key',
+        ],
+    ]);
+    $manager = new ScimAttributeMappingsManager($mock->transport(), 'org_x');
+
+    $mapping = $manager->get();
+
+    expect($mapping->mapping)->toBe(['userName' => 'email_address']);
+});
+
+it('exposes the SCIM endpoint URL for an organization', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['endpoint_url' => 'https://acme.authn.sh/scim/v2/']);
+    $manager = new ScimAttributeMappingsManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    $endpoint = $manager->endpoint();
+
+    expect($endpoint['endpoint_url'])->toBe('https://acme.authn.sh/scim/v2/');
+    expect((string) $mock->lastRequest()->getUri())
+        ->toEndWith('/v1/organizations/org_01HKX9SY9V7H7TF8C8K7J9X4ZB/scim/endpoint');
+});
+
+it('falls back to an empty endpoint_url when missing', function (): void {
+    $mock = (new MockTransport)->enqueue(body: []);
+    $manager = new ScimAttributeMappingsManager($mock->transport(), 'org_x');
+
+    expect($manager->endpoint())->toBe(['endpoint_url' => '']);
+});
+
+it('Client::organizations()->scimAttributeMappings() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: scimAttributeMappingPayload());
+    $client = new Client(secretKey: 'sk', http: $mock);
+
+    expect($client->organizations()->scimAttributeMappings('org_x'))
+        ->toBeInstanceOf(ScimAttributeMappingsManager::class);
+});

--- a/tests/Resources/ScimTokensManagerTest.php
+++ b/tests/Resources/ScimTokensManagerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use Authn\Sdk\Client;
+use Authn\Sdk\Http\ApiException;
+use Authn\Sdk\Resources\OrganizationsManager;
+use Authn\Sdk\Resources\PaginatedList;
+use Authn\Sdk\Resources\ScimToken;
+use Authn\Sdk\Resources\ScimTokensManager;
+use Authn\Sdk\Resources\ScimTokenWithPlaintext;
+use Authn\Sdk\Tests\Support\MockTransport;
+
+/**
+ * @return array<string, mixed>
+ */
+function scimTokenPayload(): array
+{
+    return [
+        'id' => 'scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA',
+        'object' => 'scim_token',
+        'organization_id' => 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'name' => 'Okta — Production',
+        'prefix' => 'scim_01HKX9SY',
+        'created_at' => 1_714_723_000_000,
+        'revoked_at' => null,
+    ];
+}
+
+it('lists SCIM tokens for an organization', function (): void {
+    $mock = (new MockTransport)->enqueue(body: [
+        'data' => [scimTokenPayload()],
+        'total_count' => 1,
+    ]);
+
+    $manager = new ScimTokensManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+    $list = $manager->list();
+
+    expect($list)->toBeInstanceOf(PaginatedList::class);
+    expect($list->totalCount)->toBe(1);
+    expect((string) $mock->lastRequest()->getUri())
+        ->toContain('/v1/organizations/org_01HKX9SY9V7H7TF8C8K7J9X4ZB/scim/tokens');
+});
+
+it('issues a fresh SCIM token returning the plaintext exactly once', function (): void {
+    $payload = scimTokenPayload();
+    $payload['token'] = 'scim_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567';
+
+    $mock = (new MockTransport)->enqueue(201, $payload);
+    $manager = new ScimTokensManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    $issued = $manager->issue('Okta — Production', idempotencyKey: 'idem-1');
+
+    expect($issued)->toBeInstanceOf(ScimTokenWithPlaintext::class);
+    expect($issued->id)->toBe('scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+    expect($issued->organizationId)->toBe('org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+    expect($issued->name)->toBe('Okta — Production');
+    expect($issued->prefix)->toBe('scim_01HKX9SY');
+    expect($issued->token)->toBe('scim_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567');
+    expect($issued->isRevoked())->toBeFalse();
+
+    expect($mock->lastRequest()->getMethod())->toBe('POST');
+    expect($mock->lastRequest()->getHeaderLine('Idempotency-Key'))->toBe('idem-1');
+    expect((string) $mock->lastRequest()->getBody())
+        ->toBe('{"name":"Okta — Production"}');
+});
+
+it('auto-generates a stable idempotency key when caller omits one', function (): void {
+    $payload = scimTokenPayload();
+    $payload['token'] = 'scim_PLAINTEXT';
+
+    $mockA = (new MockTransport)->enqueue(201, $payload);
+    $mockB = (new MockTransport)->enqueue(201, $payload);
+
+    (new ScimTokensManager($mockA->transport(), 'org_x'))->issue('Okta');
+    (new ScimTokensManager($mockB->transport(), 'org_x'))->issue('Okta');
+
+    expect($mockA->lastRequest()->getHeaderLine('Idempotency-Key'))
+        ->not->toBe('')
+        ->and($mockA->lastRequest()->getHeaderLine('Idempotency-Key'))
+        ->toBe($mockB->lastRequest()->getHeaderLine('Idempotency-Key'));
+});
+
+it('rejects payloads that omit the plaintext token on issue', function (): void {
+    $mock = (new MockTransport)->enqueue(201, scimTokenPayload());
+    $manager = new ScimTokensManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    expect(fn () => $manager->issue('Okta'))->toThrow(RuntimeException::class);
+});
+
+it('revokes a SCIM token and surfaces the revoked timestamp', function (): void {
+    $revoked = scimTokenPayload();
+    $revoked['revoked_at'] = 1_714_724_000_000;
+
+    $mock = (new MockTransport)->enqueue(body: $revoked);
+    $manager = new ScimTokensManager($mock->transport(), 'org_01HKX9SY9V7H7TF8C8K7J9X4ZB');
+
+    $token = $manager->revoke('scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA');
+
+    expect($token)->toBeInstanceOf(ScimToken::class);
+    expect($token->isRevoked())->toBeTrue();
+    expect($token->revokedAt)->toBe(1_714_724_000_000);
+    expect($mock->lastRequest()->getMethod())->toBe('POST');
+    expect((string) $mock->lastRequest()->getUri())
+        ->toEndWith('/v1/organizations/org_01HKX9SY9V7H7TF8C8K7J9X4ZB/scim/tokens/scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA/revoke');
+});
+
+it('surfaces 404 errors from the API as ApiException', function (): void {
+    $mock = (new MockTransport)->enqueue(404, [
+        'errors' => [['code' => 'scim_token_not_found', 'message' => 'not found', 'long_message' => '...']],
+    ]);
+    $manager = new ScimTokensManager($mock->transport(), 'org_x');
+
+    expect(fn () => $manager->revoke('scimt_missing'))->toThrow(ApiException::class);
+});
+
+it('Client::organizations()->scimTokens() wires through correctly', function (): void {
+    $mock = (new MockTransport)->enqueue(body: ['data' => [], 'total_count' => 0]);
+    $client = new Client(secretKey: 'sk', http: $mock);
+    $orgs = $client->organizations();
+
+    expect($orgs)->toBeInstanceOf(OrganizationsManager::class);
+    expect($orgs->scimTokens('org_x'))->toBeInstanceOf(ScimTokensManager::class);
+});


### PR DESCRIPTION
Closes #49.

Adds the v0.7 SCIM admin surface — operator-scoped (bearer-secret) SCIM token + attribute-mapping CRUD per organization, mirroring the v0.6 FAPI surface. Backed by AU-12 (BAPI mirror, authn#253) and OA-6 (spec, openapi#103). Carried over from v0.6 when the BAPI endpoints didn't yet exist.

## What's in

- `ScimTokensManager` — `list()`, `issue(name)`, `revoke(id)`. The issue endpoint returns the plaintext token **exactly once** via `ScimTokenWithPlaintext`; every subsequent read exposes only the prefix.
- `ScimAttributeMappingsManager` — `get()`, `put(mapping)`, `endpoint()`. `put()` is a full-resource replace — unsupplied keys revert to server defaults (no per-field PATCH).
- DTOs: `ScimToken`, `ScimTokenWithPlaintext`, `ScimAttributeMapping`.
- Surfaced via `\$client->organizations()->scimTokens(\$orgId)` + `\$client->organizations()->scimAttributeMappings(\$orgId)`, following the existing per-org sub-manager pattern (the issue body sketched `\$authn->organizations(\$orgId)->scimTokens()` but the actual client uses no-arg `organizations()` — adapting to the established convention rather than breaking it).

## Test plan

- [x] `composer test` — 211 tests, 621 assertions all pass (13 new SCIM tests added).
- [x] `composer phpstan` — clean.
- [x] `composer pint` — clean.