### PR TITLE
SP-3: TokenVerifier surfaces custom-template claims as customClaims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - `ScimTokensManager` — BAPI binding for `/v1/organizations/{org_id}/scim/tokens` (`list`, `issue(name)`, `revoke(id)`) plus the `ScimToken` DTO (`id`, `organizationId`, `name`, `prefix`, `createdAt`, `revokedAt`) and `ScimTokenWithPlaintext` (issue-response only — carries the full `token` plaintext exactly once). Accessible via `$client->organizations()->scimTokens($orgId)`.
 - `ScimAttributeMappingsManager` — BAPI binding for `/v1/organizations/{org_id}/scim/attribute-mappings` (`get`, `put(mapping)`) and `/v1/organizations/{org_id}/scim/endpoint` (`endpoint()`). Plus the `ScimAttributeMapping` DTO. Accessible via `$client->organizations()->scimAttributeMappings($orgId)`. `put()` is a full-resource replace — unsupplied keys revert to server defaults.
+- `VerifiedClaims->customClaims: array<string, mixed>` — surfaces every non-reserved JWT claim parsed from a token. Reserved keys (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`, `nonce`, `sid`, `azp`, `act`, `org`, `was_test`, `fva`, `pnv`, `dsf`, `pkv`, `pkc`, `entcon`, `entacc`) are excluded. Lets consumers reading custom-template-rendered tokens (`Session.getToken({template})`) access their template-defined claims without re-parsing `raw`.
+- `VerifiedClaims::customClaim(string $key, mixed $default = null): mixed` — sugar accessor that returns `$default` when the key is missing, distinguishing absence from a legitimate `null` value (which is preserved verbatim).
+- `VerifiedClaims::RESERVED_CLAIMS` constant — the canonical list of reserved keys for callers that want to filter or introspect raw claim sets.
 
 ## [0.6.0] — 2026-05-12
 

--- a/src/Tokens/TokenVerifier.php
+++ b/src/Tokens/TokenVerifier.php
@@ -277,6 +277,13 @@ final class TokenVerifier
             ? $claims['entacc']
             : null;
 
+        $customClaims = [];
+        foreach ($claims as $key => $value) {
+            if (is_string($key) && ! in_array($key, VerifiedClaims::RESERVED_CLAIMS, true)) {
+                $customClaims[$key] = $value;
+            }
+        }
+
         return new VerifiedClaims(
             sub: $sub,
             sid: $sid,
@@ -299,6 +306,7 @@ final class TokenVerifier
             passkeyCount: $passkeyCount,
             enterpriseConnectionId: $enterpriseConnectionId,
             enterpriseAccountId: $enterpriseAccountId,
+            customClaims: $customClaims,
         );
     }
 

--- a/src/Tokens/VerifiedClaims.php
+++ b/src/Tokens/VerifiedClaims.php
@@ -13,9 +13,20 @@ final class VerifiedClaims
     public const SECOND_FACTOR_BACKUP_CODE = 'backup_code';
 
     /**
+     * Reserved JWT registered claims plus the authn.sh-emitted claim names.
+     * Anything not in this set is surfaced through {@see VerifiedClaims::$customClaims}.
+     */
+    public const RESERVED_CLAIMS = [
+        'iss', 'sub', 'aud', 'exp', 'nbf', 'iat', 'jti', 'nonce',
+        'sid', 'azp', 'act', 'org', 'was_test',
+        'fva', 'pnv', 'dsf', 'pkv', 'pkc', 'entcon', 'entacc',
+    ];
+
+    /**
      * @param  array{iss: string, sub: string, sid: string}|null  $actor  impersonation chain
      * @param  array{id: string, slg?: string, rol?: string, per?: array<int, string>}|null  $org  deprecated: use $organization
      * @param  array<string, mixed>  $raw
+     * @param  array<string, mixed>  $customClaims  non-reserved claims rendered by a JwtTemplate
      */
     public function __construct(
         public readonly string $sub,
@@ -39,7 +50,13 @@ final class VerifiedClaims
         public readonly int $passkeyCount = 0,
         public readonly ?string $enterpriseConnectionId = null,
         public readonly ?string $enterpriseAccountId = null,
+        public readonly array $customClaims = [],
     ) {}
+
+    public function customClaim(string $key, mixed $default = null): mixed
+    {
+        return array_key_exists($key, $this->customClaims) ? $this->customClaims[$key] : $default;
+    }
 
     public function hasRole(string $key): bool
     {

--- a/tests/Tokens/TokenVerifierTest.php
+++ b/tests/Tokens/TokenVerifierTest.php
@@ -518,3 +518,86 @@ it('preserves entcon and entacc across impersonation (actor) sessions', function
     expect($verified->enterpriseConnectionId)->toBe('entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA');
     expect($verified->enterpriseAccountId)->toBe('entacc_01HKX9SY9V7H7TF8C8K7J9X4ZB');
 });
+
+it('surfaces custom-template claims as customClaims', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['email'] = 'jane@acme.example';
+    $claims['role'] = 'authenticated';
+    $claims['org_slug'] = 'acme';
+    $claims['tier'] = 'pro';
+    $claims['metadata'] = ['plan' => 'team', 'seats' => 25];
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->customClaims)->toBe([
+        'email' => 'jane@acme.example',
+        'role' => 'authenticated',
+        'org_slug' => 'acme',
+        'tier' => 'pro',
+        'metadata' => ['plan' => 'team', 'seats' => 25],
+    ]);
+    expect($verified->customClaim('tier'))->toBe('pro');
+    expect($verified->customClaim('metadata'))->toBe(['plan' => 'team', 'seats' => 25]);
+});
+
+it('excludes every reserved claim from customClaims', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['org'] = ['id' => 'org_1', 'slg' => 'acme'];
+    $claims['fva'] = [10, 20];
+    $claims['pnv'] = true;
+    $claims['dsf'] = 'totp';
+    $claims['pkv'] = true;
+    $claims['pkc'] = 1;
+    $claims['entcon'] = 'entcon_x';
+    $claims['entacc'] = 'entacc_y';
+    $claims['act'] = ['iss' => $claims['iss'], 'sub' => 'user_admin', 'sid' => 'sess_admin'];
+    $claims['jti'] = 'jti-1';
+    $claims['aud'] = 'api-gateway';
+    $claims['nonce'] = 'n-1';
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->customClaims)->toBe([]);
+});
+
+it('defaults customClaims to an empty array when only reserved claims are present', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $verified = $verifier->verify($fixture->sign(validClaims()));
+
+    expect($verified->customClaims)->toBe([]);
+});
+
+it('customClaim returns the supplied default when the key is missing', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['tier'] = 'pro';
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->customClaim('tier', 'free'))->toBe('pro');
+    expect($verified->customClaim('plan', 'starter'))->toBe('starter');
+    expect($verified->customClaim('missing'))->toBeNull();
+});
+
+it('preserves a null value stored in customClaims', function (): void {
+    $fixture = new JwtFixture;
+    $verifier = makeVerifier(new StaticBodyClient($fixture->jwksJson()));
+
+    $claims = validClaims();
+    $claims['feature_flag'] = null;
+
+    $verified = $verifier->verify($fixture->sign($claims));
+
+    expect($verified->customClaims)->toHaveKey('feature_flag');
+    expect($verified->customClaim('feature_flag', 'fallback'))->toBeNull();
+});


### PR DESCRIPTION
Closes #50.

Adds `VerifiedClaims->customClaims: array<string, mixed>` and a `customClaim(key, default)` accessor so consumers verifying tokens minted by a `JwtTemplate` (AU-3, authn#239) can read template-defined claims without re-parsing `\$raw`.

## What's in

- `VerifiedClaims::RESERVED_CLAIMS` — canonical reserved-claim list (standard JWT registered + authn.sh-emitted: `sid`, `azp`, `act`, `org`, `was_test`, `fva`, `pnv`, `dsf`, `pkv`, `pkc`, `entcon`, `entacc`, plus `nonce`).
- `VerifiedClaims->customClaims: array<string, mixed>` — every non-reserved JWT claim, with values preserved verbatim (including `null`).
- `VerifiedClaims::customClaim(string \$key, mixed \$default = null): mixed` — sugar accessor distinguishing absence from a legitimate `null` value via `array_key_exists`.
- `TokenVerifier::buildVerifiedClaims()` partitions every non-reserved string-keyed claim into `customClaims` on parse.

Five new Pest cases cover the happy path, the reserved-claim exclusion, the empty-default behaviour, the `customClaim()` accessor, and the `null`-value preservation edge case.

## Test plan

- [x] `composer test` — token verifier suite (41 tests, 115 assertions) all pass.
- [x] `composer phpstan` — clean.
- [x] `composer pint` — clean.

Server-side template renderer (AU-3, authn#239) still pending; this SDK-side parsing works against any token whose payload includes non-reserved claims, so it can ship before the server lands.